### PR TITLE
Update to SBA section now supports customid of potteryhouse's version of SBA

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,15 +3,15 @@ EasyPopulate 4.0 Beta SBA_Stock
 There is a Zen-cart.com Support Thread located here:
 http://www.zen-cart.com/forum/showthread.php?t=190417
 
-I recommend that you first enter a couple Categories and Products through the normal Zencart Admin. This will help you understand the exported file formats.
+I recommend that you first enter a couple Categories and Products through the normal Zencart Admin. This will help you understand the exported file formats and how to import.
 
-Things of Import:
+Things of Importance:
 
 1) EP4 works only with CSV data files, and for best cross platform compatibility please use OpenOffice to Export your CSV file.
 You should select the Comma as your field delimiter, and the Double Quote as your text delimiter. You may not get proper results using Excel.
 
 2) You MUST use products_models to distinguish your products for import. Any record with a blank v_products_model entry will be skipped.
-   Also note that is you enter the same products_model twice, the latest record entry will over-write any previous entries. The exception
+   Also note that if you enter the same products_model twice, the latest record entry will over-write any previous entries. The exception
    here is if you enter a different category; this will result in a linked product. "Duplicate" products with the same products_model number
    is not supported. If you have these entries in your database, you may get unpredictable results.
 
@@ -23,25 +23,25 @@ names are separated by the Carat "^" symbol. For Example: Bar Supplies^Glass Was
 
 Be careful when creating your category names. "Bar Supplies" is not equal to "BAR Supplies" ... this will result in TWO category entries.
 
-As of 4.0.17, your lowest defined language (by language id) is needed to when creating categories. In the future I'll change this to the defined default language, but that
+As of 4.0.17, your lowest defined language (by language id) is needed to be used when creating categories. In the future I'll change this to the defined default language, but that
 will take some additional work.
 
-4) Work flow is somewhat different than other version of EP. With EP4 you first upload your file, then click on Import. Optionally you can also Split an import file if it is too large. You can set the number of records to split on in the configuration settings. Default is 2000. If you have a powerful server, you can up this significantly. Testing on a VPS with an import file of 900,000 records, I broke into 50,000 record segments. Import of each 50,000 records took about 250 seconds.
+4) Work flow is somewhat different than other versions of EP. With EP4 you first upload your file, then click on Import. Optionally you can also Split an import file if it is too large. You can set the number of records to split on in the configuration settings. Default is 2000. If you have a powerful server, you can increase this significantly. Testing on a VPS with an import file of 900,000 records, I broke the file into 50,000 record segments. Import of each 50,000 records took about 250 seconds.
 
-Also NO streaming upload or download support. Sorry if you liked this feature. A lot of effort has been put into improving the code's performance and streaming the data was a real memory hog. To download your exported file, you will need to "right-click, save-as". You may be able to set your browser to automatically download CSV files. I'll come up with a better solution in due time. 
+Also there is NO streaming upload or download support. Sorry if you liked this feature. A lot of effort has been put into improving the code's performance and streaming the data was a real memory hog. To download your exported file, you will need to "right-click, save-as". You may be able to set your browser to automatically download csv/CSV files. I'll come up with a better solution in due time. 
 
-5) File names act as a switch inside the script for Importing. Namely: PriceBreaks-EP, CategoryMeta-EP, Featured-EP, and Attrib-Basic-EP/Attrib-Detailed-EP ... these import files must have names that start with these string.
+5) File names act as a switch inside the script for Importing. Namely: PriceBreaks-EP, CategoryMeta-EP, Featured-EP, SBA-Stock-EP, and Attrib-Basic-EP/Attrib-Detailed-EP ... these import files must have names that start with this string.
 
 6) Basic Attribute Import. Please read the notes below carefully for how to use this feature which is still in development. Currently, you can at Import create your products_options_name (your attribute name, ie. color) , products_options_type (checkbox, dropdown, etc) and, products_options_values_name (red, green, blue).
 
-Be sure to backup you data before importing your files. Remember, this is still "beta". I have made every attempt to make this a solid bug free product, but it does require more testing. I have added a lot of error trapping, but I'm sure I've missed things.
+Be sure to backup your data before importing your files. Remember, this is still "beta". I have made every attempt to make this a solid bug free product, but it does require more testing. I have added a lot of error trapping, but I'm sure I've missed things.
 
 
 IMPORTING ATTRIBUTES
 Including sample attribute input file.
 
 I am currently able to correctly import basic attributes, and assign 
-the options to an associated products model. It is possible to create
+the options to an associated product's model. It is possible to create
 multiple sets of Option Names / Option Values and assign to a single 
 product, say "Size" and "Color".
 
@@ -59,26 +59,28 @@ CSV file currently has 4 column:
 		3 - Check Box
 		4 - File Upload
 		5 - Read Only
-	b) for a giving option_name (say "Color"), do not change the products_option_type
+	b) for a given option_name (say "Color"), do not change the products_option_type
 	   on subsequent entries, doing so will not give the results you want.
 	c) If you need a "Color" with both a drop down box and check box, you will need
 	   to define two unique Options Names.
 
 3) v_products_options_name_1
-	a) The option name you want to create
+	a) The option name you want to create or use
 	b) It is important to note that Zen Cart will allow you to create
 	   from within the admin two identical Options names, and assign 
-	   uniques options values to each. For example:
-		"Color" with "red,green,blue" 
-		"Color" with "cyan,magenta,yellow"
-	   Internally, Zen Cart knows these are two distinct options, 
+	   unique options values to each. For example:
+		"Color" with "red,green,blue" as one option name/value pair
+		"Color" with "cyan,magenta,yellow" as another option name/value pair
+	   Internally, Zen Cart knows these are two distinct options names, 
 	   but this info is not available to the user. (It would have been
 	   better to have a unique Options Name, and associated Options Display Name
 	   which in turn could be language specific).
 	c) For this reason, the products_options_name_1 must be unique, meaning
-	   you CAN have "Colors" but the assiated options_values set will be
-	   the sum of the example above: { red,green,blue,cyan,magenta,yellow }.
-
+	   you CAN have "Colors" but the associated options_values set will be
+	   the sum of the example above: { red,green,blue,cyan,magenta,yellow }.  
+	   (This is information in the database. The product will still only show 
+	   the attributes assigned.)
+	   
 4) v_products_options_values_names_1
 	a) these are the values names that are assigned to the products_options_name
 	b) enter the values_names, delimited with a comma
@@ -89,9 +91,9 @@ IMPORTANT NOTE:
 When creating your CSV file, please use Open Office (it's free!). When you save 
 CSV files from OO, it will properly encapsulate all fields. Excel will not 
 necessarily do this, depending on your data, and the export CSV option 
-you pick from within Excel.
+you pick from within Excel, also dates and date formats may be revised by Excel.
 
-In the /examples directory is an sample input files: Attrib-Basic-EP-examples.csv
+In the /examples directory is an sample input file: Attrib-Basic-EP-examples.csv
 
 The "Detailed Products Attributes" shows all attribute details assigned to a given products_model,
 with one line per option_name. So a product with a dropbox of 3 colors will result in 3 lines of
@@ -108,15 +110,19 @@ The two primary characteristics to consider when using EP4 are the columns (head
 2. Status (product enabled or disabled)
 3. Product Name in each language entered shifting the remaining columns to the right.
 4. Product Description without html tags (no <br/>, <p>, etc.) (In each language entered shifting the remaining columns to the right.)
-5. Whether the item listed in the row is tracked by Stock by Attributes (SBA) using a marker if yes and leaving the row's field blank if no.
-6. A unique identifier associated with the data type of item in the row.
-7. The attributes associated with the item in the row (if any exist) put together in the format OptionName1: OptionValue1; OptionName2: OptionValue2; etc... OptionName1 may be the same as OptionName2 and still will be listed as shown.
-8. The quantity of the item in the row.
+5. If potteryhouse's version of SBA is installed (or the customid field exists in addition to some other fields) then this column will have the customid, otherwise, all of the columns below will move left to replace what would be in this column.
+6. Whether the item listed in the row is tracked by Stock by Attributes (SBA) using a marker if yes and leaving the row's field blank if no.
+7. A unique identifier associated with the data type of item in the row.
+8. The attributes associated with the item in the row (if any exist) put together in the format OptionName1: OptionValue1; OptionName2: OptionValue2; etc... OptionName1 may be the same as OptionName2 and still will be listed as shown.
+9. The quantity of the item in the row.
 
 On upload/import, the only field that will change in the Zen Cart database with this report is the quantity associated with the row's data.
 
-Item 6 of the list was abbreviated to simplify the explanation. For an entry displayed that shows the total quantity associated with a product, the value in that column is the products_id taken from the products table of the database. For a row that contains SBA information, the value is the stock_id taken from the products_with_attributes_stock table. These values are provided to support import of the data and for normal operation, they should not be revised. The position of the column was chosen to not place it adjacent to a field that is likely to be changed by the user. (Technically for EP4 to import this new file, the only two columns important for the import are the ones located in items 5, 6 and 8, all of the other columns were provided to help the individual performing the stock inventory identify the product(s).) Ideally, column 6 would not exist and instead the program would determine the appropriate value for that column based on other information in the table so that the spreadsheet would not be dependent on the current database but could be applied to any database at any time.  This will require a revision to accomplish.
-This brings us to the arrangement of the rows. Every row of data has the potential of having attributes associated with the product, but every product has a quantity associated with it.  On export, every product will be listed, whether an active product or not. If a product is tracked by SBA, then the product's data will be provided first, followed by the SBA associated data. So if a product has two option values (green and blue) for a single option name (Color) but is not tracked by SBA then in the row for that product the attributes column (item 7 of above) and if there were 70 of this product (item 8 of above) will show as:
+Item 7 of the list was abbreviated to simplify the explanation. For an entry displayed that shows the total quantity associated with a product, the value in that column is the products_id taken from the products table of the database. For a row that contains SBA information, the value is the stock_id taken from the products_with_attributes_stock table. These values are provided to support import of the data and they should not be revised for normal operation. The position of the column was chosen to not place it adjacent to a field that is likely to be changed by the user. (Technically for EP4 to import this new file, the only two columns important for the import are the ones located in items 6, 7 and 9, all of the other columns were provided to help the individual performing the stock inventory identify the product(s).) Ideally, column 7 would not exist and instead the program would determine the appropriate value for that column based on other information in the table so that the spreadsheet would not be dependent on the current database but could be applied to any database at any time.  This will require a revision to accomplish.
+
+This brings us to the arrangement of the rows. Every row of data has the potential of having attributes associated with the product, but every product has a quantity associated with it.  Below are two examples 1) of a product without attributes, the other with attributes as described. 
+
+On export, every product will be listed, whether an active product or not. If a product is tracked by SBA, then the product's data will be provided as the first row for that product, followed by rows of the SBA associated data. So if a product has two option values (green and blue) for a single option name (Color) but is not tracked by SBA then in the row for that product the attributes column (item 7 of above) and quantity (item 8 of above) assuming 70 of this product will show as:
 
 Product has no attributes:
 | Attribute(s)              | Quantity

--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ Also there is NO streaming upload or download support. Sorry if you liked this f
 
 6) Basic Attribute Import. Please read the notes below carefully for how to use this feature which is still in development. Currently, you can at Import create your products_options_name (your attribute name, ie. color) , products_options_type (checkbox, dropdown, etc) and, products_options_values_name (red, green, blue).
 
-Be sure to backup your data before importing your files. Remember, this is still "beta". I have made every attempt to make this a solid bug free product, but it does require more testing. I have added a lot of error trapping, but I'm sure I've missed things.
+LASTLY but definitely not LEAST and applicable to all of EP4: Be sure to backup your data before importing your files. Remember, this is still "beta". I have made every attempt to make this a solid bug free product, but it does require more testing. I have added a lot of error trapping, but I'm sure I've missed things.
 
 
 IMPORTING ATTRIBUTES

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.23 07-13-2014 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.26 10-19-2014 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.25 - Beta 10-11-2014';
+$curver              = '4.0.26 - Beta 10-19-2014';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.26 10-19-2014 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.26a 10-25-2014 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.26 - Beta 10-19-2014';
+$curver              = '4.0.26a - Beta 10-25-2014';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -402,7 +402,7 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
     <a href="easypopulate_4.php?export=attrib_basic"><b>Basic Products Attributes</b> (basic single-line)</a><br /> 
     <a href="easypopulate_4.php?export=attrib_detailed"><b>Detailed Products Attributes</b> (detailed multi-line)</a><br />
 <?php
-	if (ep_4_SBAEnabled != false) { 
+	if ($ep_4_SBAEnabled != false) { 
 	?>
     <a href="easypopulate_4.php?export=SBA_detailed"><b>Detailed Stock By Attributes Data</b> (detailed multi-line)</a><br />
     <a href="easypopulate_4.php?export=SBAStock"><b>Stock of Items with Attributes Including SBA</b></a><br />

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.26a 10-25-2014 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.27 11-02-2014 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.26a - Beta 10-25-2014';
+$curver              = '4.0.27 - Beta 11-02-2014';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -58,7 +58,7 @@ $has_specials        = false;
 $ep_supported_mods = array();
 
 // default smart-tags setting when enabled. This can be added to.
-$smart_tags = array("\r\n|\r|\n" => '<br />', ); // need to check into this more
+$smart_tags = array("\r\n|\r|\n" => '<br/>', ); // need to check into this more
 
 if (substr($tempdir, -1) != '/') $tempdir .= '/';
 if (substr($tempdir, 0, 1) == '/') $tempdir = substr($tempdir, 1);
@@ -259,11 +259,11 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
     
 	<div style="text-align:right; float:right; width:25%"><a href="<?php echo zen_href_link(FILENAME_EASYPOPULATE_4, 'epinstaller=remove') ?>">Un-Install EP4</a>
     <?php
-		echo '<br><b><u>Configuration Settings</u></b><br>';
-		echo 'Upload Directory: <b>'.$tempdir.'</b><br>'; 
-		echo 'Verbose Feedback: '.(($ep_feedback) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo 'Split Records: '.$ep_split_records.'<br>';
-		echo 'Execution Time: '.$ep_execution.'<br>';
+		echo '<br/><b><u>Configuration Settings</u></b><br/>';
+		echo 'Upload Directory: <b>'.$tempdir.'</b><br/>'; 
+		echo 'Verbose Feedback: '.(($ep_feedback) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo 'Split Records: '.$ep_split_records.'<br/>';
+		echo 'Execution Time: '.$ep_execution.'<br/>';
 		switch ($ep_curly_quotes) {
 			case 0:
 			$ep_curly_text = "No Change";
@@ -286,41 +286,43 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 			$ep_char92_text = "HTML";
 			break;
 		}
-		echo 'Convert Curly Quotes: '.$ep_curly_text.'<br>';
-		echo 'Convert Char 0x92: '.$ep_char92_text.'<br>';
-		echo 'Enable Products Metatags: '.$ep_metatags.'<br>';
-		echo 'Enable Products Music: '.$ep_music.'<br>';
+		echo 'Convert Curly Quotes: '.$ep_curly_text.'<br/>';
+		echo 'Convert Char 0x92: '.$ep_char92_text.'<br/>';
+		echo 'Enable Products Metatags: '.$ep_metatags.'<br/>';
+		echo 'Enable Products Music: '.$ep_music.'<br/>';
 			
-		echo '<br><b><u>Custom Products Fields</u></b><br>';
-		echo 'Product Short Descriptions: '.(($ep_supported_mods['psd']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo 'Product Unit of Measure: '.(($ep_supported_mods['uom']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo 'Product UPC Code: '.(($ep_supported_mods['upc']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
+		echo '<br/><b><u>Custom Products Fields</u></b><br/>';
+		echo 'Product Short Descriptions: '.(($ep_supported_mods['psd']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo 'Product Unit of Measure: '.(($ep_supported_mods['uom']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo 'Product UPC Code: '.(($ep_supported_mods['upc']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 		// Google Product Category for Google Merchant Center
-		echo 'Google Product Category: '.(($ep_supported_mods['gpc']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo "Manufacturer's Suggested Retail Price: ".(($ep_supported_mods['msrp']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo "Group Pricing Per Item: ".(($ep_supported_mods['gppi']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
-		echo "Exclusive Products Mod: ".(($ep_supported_mods['excl']) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
+		echo 'Google Product Category: '.(($ep_supported_mods['gpc']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo "Manufacturer's Suggested Retail Price: ".(($ep_supported_mods['msrp']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo "Group Pricing Per Item: ".(($ep_supported_mods['gppi']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+		echo "Exclusive Products Mod: ".(($ep_supported_mods['excl']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+ 		echo "Stock By Attributes Mod: ".(($ep_4_SBAEnabled != false) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 
-		echo "<br><b><u>User Defined Products Fields: </b></u><br>";
+
+		echo "<br/><b><u>User Defined Products Fields: </b></u><br/>";
 		$i = 0;
 		foreach ($custom_field_names as $field) {
-			echo $field.': '.(($custom_field_check[$i]) ? '<font color="green">TRUE</font>':"FALSE").'<br>';
+			echo $field.': '.(($custom_field_check[$i]) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 			$i++;
 		}
 		
-		echo '<br><b><u>Installed Languages</u></b> <br>';
+		echo '<br/><b><u>Installed Languages</u></b> <br/>';
 		foreach ($langcode as $key => $lang) {
-			echo $lang['id'].'-'.$lang['code'].': '.$lang['name'].'<br>';
+			echo $lang['id'].'-'.$lang['code'].': '.$lang['name'].'<br/>';
 		}
-		echo 'Default Language: '.	$epdlanguage_id .'-'. $epdlanguage_name.'<br>';
-		echo 'Internal Character Encoding: '.mb_internal_encoding().'<br>';
-		echo 'DB Collation: '.$collation.'<br>';
+		echo 'Default Language: '.	$epdlanguage_id .'-'. $epdlanguage_name.'<br/>';
+		echo 'Internal Character Encoding: '.mb_internal_encoding().'<br/>';
+		echo 'DB Collation: '.$collation.'<br/>';
 		
-		echo '<br><b><u>Database Field Lengths</u></b><br>';
-		echo 'categories_name:'.$categories_name_max_len.'<br>';
-		echo 'manufacturers_name:'.$manufacturers_name_max_len.'<br>';
-		echo 'products_model:'.$products_model_max_len.'<br>';
-		echo 'products_name:'.$products_name_max_len.'<br>';
+		echo '<br/><b><u>Database Field Lengths</u></b><br/>';
+		echo 'categories_name:'.$categories_name_max_len.'<br/>';
+		echo 'manufacturers_name:'.$manufacturers_name_max_len.'<br/>';
+		echo 'products_model:'.$products_model_max_len.'<br/>';
+		echo 'products_name:'.$products_name_max_len.'<br/>';
 	
 	/*  // some error checking
 		echo '<br><br>Problem Data: '. mysql_num_rows($ajeh_result);
@@ -339,13 +341,13 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 	<div style="text-align:left">
             
     <form ENCTYPE="multipart/form-data" ACTION="easypopulate_4.php" METHOD="POST">
-        <div align = "left"><br />
-            <b>Upload EP File</b><br />
+        <div align = "left"><br/>
+            <b>Upload EP File</b><br/>
             <?php echo "Http Max Upload File Size: $upload_max_filesize bytes (".round($upload_max_filesize/1024/1024)." Mbytes)<br/>";?>
             <input TYPE="hidden" name="MAX_FILE_SIZE" value="<?php echo $upload_max_filesize; ?>">
             <input name="uploadfile" type="file" size="50">
             <input type="submit" name="buttoninsert" value="Upload File">
-            <br /><br><br>
+            <br/><br/><br/>
         </div>
     </form>
 
@@ -376,7 +378,7 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 			array( "id" => '1', 'text' => "Model/Price/Qty" ),
 			array( "id" => '2', 'text' => "Model/Price/Breaks" ));
 		
-		echo "<b>Filterable Exports:</b><br>";
+		echo "<b>Filterable Exports:</b><br/>";
 		
 		echo zen_draw_pull_down_menu('ep_export_type', $export_type_array) . ' ';
 		echo ' ' . zen_draw_pull_down_menu('ep_category_filter', array_merge(array( 0 => array( "id" => '', 'text' => "Categories" )), zen_get_category_tree())) . ' ';
@@ -384,42 +386,42 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 		echo ' ' . zen_draw_pull_down_menu('ep_status_filter', $status_array) . ' ';
 		echo zen_draw_input_field('export', 'Export', ' style="padding: 0px"', false, 'submit');
 		?>				
-    <br /><br>
+    <br/><br/>
     </div>
 
-    <b>Product &amp; Pricing Export/Import Options:</b><br />
+    <b>Product &amp; Pricing Export/Import Options:</b><br/>
     <!-- Download file links -->
-    <a href="easypopulate_4.php?export=full"><b>Complete Products</b> (with Metatags)</a><br />
-    <a href="easypopulate_4.php?export=priceqty"><b>Model/Price/Qty</b> (with Specials)</a><br />
-    <a href="easypopulate_4.php?export=pricebreaks"><b>Model/Price/Breaks</b></a><br />
-    <a href="easypopulate_4.php?export=featured"><b>Featured Products</b></a><br />
+    <a href="easypopulate_4.php?export=full"><b>Complete Products</b> (with Metatags)</a><br/>
+    <a href="easypopulate_4.php?export=priceqty"><b>Model/Price/Qty</b> (with Specials)</a><br/>
+    <a href="easypopulate_4.php?export=pricebreaks"><b>Model/Price/Breaks</b></a><br/>
+    <a href="easypopulate_4.php?export=featured"><b>Featured Products</b></a><br/>
     
-    <br><b>Category Export/Import Options</b><br>
-    <a href="easypopulate_4.php?export=category"><b>Model/Category</b></a><br />
-    <a href="easypopulate_4.php?export=categorymeta"><b>Categories Only</b> (with Metatags)</a><br />
+    <br/><b>Category Export/Import Options</b><br/>
+    <a href="easypopulate_4.php?export=category"><b>Model/Category</b></a><br/>
+    <a href="easypopulate_4.php?export=categorymeta"><b>Categories Only</b> (with Metatags)</a><br/>
     
-    <br><b>Attribute Export/Import Options</b><br>
-    <a href="easypopulate_4.php?export=attrib_basic"><b>Basic Products Attributes</b> (basic single-line)</a><br /> 
-    <a href="easypopulate_4.php?export=attrib_detailed"><b>Detailed Products Attributes</b> (detailed multi-line)</a><br />
+    <br/><b>Attribute Export/Import Options</b><br/>
+    <a href="easypopulate_4.php?export=attrib_basic"><b>Basic Products Attributes</b> (basic single-line)</a><br/> 
+    <a href="easypopulate_4.php?export=attrib_detailed"><b>Detailed Products Attributes</b> (detailed multi-line)</a><br/>
 <?php
 	if ($ep_4_SBAEnabled != false) { 
 	?>
-    <a href="easypopulate_4.php?export=SBA_detailed"><b>Detailed Stock By Attributes Data</b> (detailed multi-line)</a><br />
-    <a href="easypopulate_4.php?export=SBAStock"><b>Stock of Items with Attributes Including SBA</b></a><br />
+    <a href="easypopulate_4.php?export=SBA_detailed"><b>Detailed Stock By Attributes Data</b> (detailed multi-line)</a><br/>
+    <a href="easypopulate_4.php?export=SBAStock"><b>Stock of Items with Attributes Including SBA</b></a><br/>
 
-    <a href="easypopulate_4.php?export=SBAStockProdFilter"><b>Stock of Items with Attributes Including SBA Sorted Ascending</b></a><br />
+    <a href="easypopulate_4.php?export=SBAStockProdFilter"><b>Stock of Items with Attributes Including SBA Sorted Ascending</b></a><br/>
 
 <?php } ?>
     
-    <br>DIAGNOSTIC EXPORTS - Note: NOT FOR IMPORTING ATTRIBUTES!<br>
-    <a href="easypopulate_4.php?export=options"><b>Attribute Options Names</b></a><br />
-    <a href="easypopulate_4.php?export=values"><b>Attribute Options Values</b></a><br />
-    <a href="easypopulate_4.php?export=optionvalues"><b>Attribute Options-Names-to-Values</b></a><br />
+    <br>DIAGNOSTIC EXPORTS - Note: NOT FOR IMPORTING ATTRIBUTES!<br/>
+    <a href="easypopulate_4.php?export=options"><b>Attribute Options Names</b></a><br/>
+    <a href="easypopulate_4.php?export=values"><b>Attribute Options Values</b></a><br/>
+    <a href="easypopulate_4.php?export=optionvalues"><b>Attribute Options-Names-to-Values</b></a><br/>
 
 	<?php   
     // List uploaded files in multifile mode
 	// Table header
-	echo '<br><br>';
+	echo '<br/><br/>';
 	echo "<table id=\"epfiles\"    width=\"80%\" border=1 cellspacing=\"2\" cellpadding=\"2\">\n";
 	echo "<tr><th>File Name</th><th>Size</th><th>Date &amp; Time</th><th>Type</th><th>Split</th><th>Import</th><th>Delete</th><th>Download</th>\n";
     // $upload_dir = DIR_FS_CATALOG.$tempdir; // defined above
@@ -504,11 +506,11 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 <?php
 	echo $display_output; // upload results
 	if (strlen($specials_print) > strlen(EASYPOPULATE_4_SPECIALS_HEADING)) {
-		echo '<br />' . $specials_print . EASYPOPULATE_4_SPECIALS_FOOTER; // specials summary
+		echo '<br/>' . $specials_print . EASYPOPULATE_4_SPECIALS_FOOTER; // specials summary
 	}	
 ?>
 </div>
-<br />
+<br/>
 <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
 </body>
 </html>

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.27 11-02-2014 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.28 11-25-2014 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.27 - Beta 11-02-2014';
+$curver              = '4.0.28 - Beta 11-25-2014';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -140,7 +140,9 @@ if ($ep_uses_mysqli) {
 	$collation = mysql_client_encoding(); // should be either latin1 or utf8
 }
 if ($collation == 'utf8') {
-	mb_internal_encoding("UTF-8");
+  if (function_exists('mb_internal_encoding')) {
+    mb_internal_encoding("UTF-8");
+  }
 }
 
 if ( ($collation == 'utf8') && ((substr($project,0,5) == "1.3.8") || (substr($project,0,5) == "1.3.9")) ) {
@@ -315,7 +317,7 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 			echo $lang['id'].'-'.$lang['code'].': '.$lang['name'].'<br/>';
 		}
 		echo 'Default Language: '.	$epdlanguage_id .'-'. $epdlanguage_name.'<br/>';
-		echo 'Internal Character Encoding: '.mb_internal_encoding().'<br/>';
+		echo 'Internal Character Encoding: '.(function_exists('mb_internal_encoding') ? mb_internal_encoding() : 'mb_internal_encoding not available').'<br/>';
 		echo 'DB Collation: '.$collation.'<br/>';
 		
 		echo '<br/><b><u>Database Field Lengths</u></b><br/>';

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.24 - Beta 7-15-2014';
+$curver              = '4.0.25 - Beta 10-11-2014';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -178,6 +178,7 @@ if (($ep_uses_mysqli ? mysqli_num_rows($epdlanguage_query) : mysql_num_rows($epd
 }
 
 $langcode = ep_4_get_languages(); // array of currently used language codes ( 1, 2, 3, ...)
+$ep_4_SBAEnabled = ep_4_SBA1Exists();
 
 /*
 if ( isset($_GET['export2']) ) { // working on attributes export 
@@ -401,9 +402,7 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
     <a href="easypopulate_4.php?export=attrib_basic"><b>Basic Products Attributes</b> (basic single-line)</a><br /> 
     <a href="easypopulate_4.php?export=attrib_detailed"><b>Detailed Products Attributes</b> (detailed multi-line)</a><br />
 <?php
-	$ep_4_SBAEnabled = false;
-	if (ep_4_SBA1Exists() == true) { 
-		$ep_4_SBAEnabled = true;
+	if (ep_4_SBAEnabled != false) { 
 	?>
     <a href="easypopulate_4.php?export=SBA_detailed"><b>Detailed Stock By Attributes Data</b> (detailed multi-line)</a><br />
     <a href="easypopulate_4.php?export=SBAStock"><b>Stock of Items with Attributes Including SBA</b></a><br />

--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.28 11-25-2014 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.28 01-03-2015 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -26,7 +26,7 @@ $ep_curly_quotes  = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
 $ep_char_92       = (int)EASYPOPULATE_4_CONFIG_CHAR_92;
 $ep_metatags      = (int)EASYPOPULATE_4_CONFIG_META_DATA; // 0-Disable, 1-Enable
 $ep_music         = (int)EASYPOPULATE_4_CONFIG_MUSIC_DATA; // 0-Disable, 1-Enable
-$ep_uses_mysqli   = (PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR == '1.5.3' ? true : false);
+$ep_uses_mysqli   = (PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3' ? true : false);
 
 @set_time_limit($ep_execution);  // executin limit in seconds. 300 = 5 minutes before timeout, 0 means no timelimit
 
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.28 - Beta 11-25-2014';
+$curver              = '4.0.28 - Beta 01-03-2015';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -170,6 +170,13 @@ if ( ($collation == 'utf8') && ((substr($project,0,5) == "1.3.8") || (substr($pr
 // default langauage should not be important since all installed languages are used $langcode[]
 // and we should iterate through that array (even if only 1 stored value)
 // $epdlanguage_id is used only in categories generation code since the products import code doesn't support multi-language categories
+/* @var $epdlanguage_query type array */
+//$epdlanguage_query = $db->Execute("SELECT languages_id, name FROM ".TABLE_LANGUAGES." WHERE code = '".DEFAULT_LANGUAGE."'");
+if (!defined(DEFAULT_LANGUAGE)) {
+	$epdlanguage_query = ep_4_query("SELECT languages_id, code FROM ".TABLE_LANGUAGES." ORDER BY languages_id LIMIT 1");
+	$epdlanguage = ($ep_uses_mysqli ? mysqli_fetch_array($epdlanguage_query) : mysql_fetch_array($epdlanguage_query));
+	define('DEFAULT_LANGUAGE', $epdlanguage['code']);
+}
 $epdlanguage_query = ep_4_query("SELECT languages_id, name FROM ".TABLE_LANGUAGES." WHERE code = '".DEFAULT_LANGUAGE."'");
 if (($ep_uses_mysqli ? mysqli_num_rows($epdlanguage_query) : mysql_num_rows($epdlanguage_query))) {
 	$epdlanguage = ($ep_uses_mysqli ? mysqli_fetch_array($epdlanguage_query) : mysql_fetch_array($epdlanguage_query));
@@ -186,7 +193,13 @@ $ep_4_SBAEnabled = ep_4_SBA1Exists();
 if ( isset($_GET['export2']) ) { // working on attributes export 
 	include_once('easypopulate_4_export2.php'); // this file contains all data import code
 } */
-
+$ep4CEONURIDoesExist = false;
+if (ep_4_CEONURIExists() == true) {
+	$ep4CEONURIDoesExist = true;
+	if (!sizeof($languages)) {
+		$languages = zen_get_languages();
+	}
+}
 if ( isset($_POST['export']) OR isset($_GET['export'])  ) {
 	include_once('easypopulate_4_export.php'); // this file contains all data export code
 }
@@ -303,6 +316,7 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 		echo "Group Pricing Per Item: ".(($ep_supported_mods['gppi']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 		echo "Exclusive Products Mod: ".(($ep_supported_mods['excl']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
  		echo "Stock By Attributes Mod: ".(($ep_4_SBAEnabled != false) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+    echo "CEON URI Rewriter Mod: " . (($ep4CEONURIDoesExist == true) ? '<font color="green">TRUE</font>' : "FALSE") . '<br/>';
 
 
 		echo "<br/><b><u>User Defined Products Fields: </b></u><br/>";
@@ -327,12 +341,12 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 		echo 'products_name:'.$products_name_max_len.'<br/>';
 	
 	/*  // some error checking
-		echo '<br><br>Problem Data: '. mysql_num_rows($ajeh_result);
-		echo '<br>Memory Usage: '.memory_get_usage(); 
-		echo '<br>Memory Peak: '.memory_get_peak_usage();
-		echo '<br><br>';
+		echo '<br/><br/>Problem Data: '. mysql_num_rows($ajeh_result);
+		echo '<br/>Memory Usage: '.memory_get_usage(); 
+		echo '<br/>Memory Peak: '.memory_get_peak_usage();
+		echo '<br/><br/>';
 		print_r($langcode);
-		echo '<br><br>code: '.$langcode[1]['id'];
+		echo '<br/><br/>code: '.$langcode[1]['id'];
 	*/
 		//register_globals_vars_check_4(); // testing
 	
@@ -494,11 +508,11 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 	echo "<div>";
 		$test_string = "Πλαστικά^Εξαρτήματα";
 		$test_array1 = explode("^", $test_string);
-		echo "<br>Using explode() with: ".$test_string."<br>";
+		echo "<br/>Using explode() with: ".$test_string."<br/>";
 		print_r($test_array1);
 		
 		$test_array2 = mb_split('\x5e', $test_string);
-		echo "<br><br>Using mb_split() with: ".$test_string."<br>";
+		echo "<br/><br/>Using mb_split() with: ".$test_string."<br/>";
 		print_r($test_array2);
 	echo "</div>";
 	*/

--- a/admin/easypopulate_4_export.php
+++ b/admin/easypopulate_4_export.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_export.php, v4.0.25 10-10-2014 mc12345678 $
+// $Id: easypopulate_4_export.php, v4.0.26 10-19-2014 mc12345678 $
 
 // get download type
 $ep_dltype = (isset($_POST['export'])) ? $_POST['export'] : $ep_dltype;
@@ -330,7 +330,9 @@ while ($row = ($ep_uses_mysqli ?  mysqli_fetch_array($result) : mysql_fetch_arra
 			// NEW While-loop for unlimited category depth			
 			$category_delimiter = "^";
 			$thecategory_id = $row['v_categories_id']; // starting category_id
-		  
+		  if ($ep_dltype == 'category') {
+        
+      }
 			// $fullcategory = array(); // this will have the entire category path separated by $category_delimiter
 			// if parent_id is not null ('0'), then follow it up.
 			while (!empty($thecategory_id)) {

--- a/admin/easypopulate_4_import.php
+++ b/admin/easypopulate_4_import.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_import.php, v4.0.26 10-19-2014 mc12345678 $
+// $Id: easypopulate_4_import.php, v4.0.28 01-03-2015 mc12345678 $
 
 // BEGIN: Data Import Module
 if ( isset($_GET['import']) ) {
@@ -76,9 +76,9 @@ if ( isset($_GET['import']) ) {
 	$file_location = DIR_FS_CATALOG.$tempdir.$file['name'];
 	// Error Checking
 	if (!file_exists($file_location)) {
-		$display_output .='<font color="red"><b>ERROR: Import file does not exist:'.$file_location.'</b></font><br>';
+		$display_output .='<font color="red"><b>ERROR: Import file does not exist:'.$file_location.'</b></font><br/>';
 	} else if ( !($handle = fopen($file_location, "r"))) {
-		$display_output .= '<font color="red"><b>ERROR: Cannot open import file:'.$file_location.'</b></font><br>';
+		$display_output .= '<font color="red"><b>ERROR: Cannot open import file:'.$file_location.'</b></font><br/>';
 	}
 	
 	// Read Column Headers
@@ -131,6 +131,9 @@ if ( isset($_GET['import']) ) {
 						WHERE (
 						featured_id = '".$v_featured_id."')";
 					$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Updated featured product with featured_id ' . (int)$v_featured_id . ' via EP4.', 'info');
+            }
 					$ep_update_count++;
 				} else {
 					// add featured product
@@ -162,6 +165,9 @@ if ( isset($_GET['import']) ) {
 						status                  = ".(int)$v_status.",
 						featured_date_available = '".$v_featured_date_available."'";
 					$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Inserted product ' . (int)$v_products_id . ' via EP4 into featured table.', 'info');
+            }
 					$ep_update_count++;
 				}
 			} else { // ERROR: This products_model doen't exist!
@@ -219,6 +225,9 @@ if ( isset($_GET['import']) ) {
 					options_id = ".$items[$filelayout['v_options_id']]." AND 
 					options_values_id = ".$items[$filelayout['v_options_values_id']].")";
 				$result = ep_4_query($sql);
+          if ($result) {
+            zen_record_admin_activity('Updated products attributes ' . (int)$items[$filelayout['v_products_attributes_id']] . ' of product ' . $items[$filelayout['v_products_id']] . ' having option ' . $items[$filelayout['v_options_id']] . ' and option value ' . $items[$filelayout['v_options_values_id']] . ' via EP4.', 'info');
+          }
 				
 				if ($items[$filelayout['v_products_attributes_filename']] <> '') { // download file name
 					$sql = 'SELECT * FROM '.TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD.' 
@@ -232,6 +241,9 @@ if ( isset($_GET['import']) ) {
 							WHERE ( 
 							products_attributes_id = ".$items[$filelayout['v_products_attributes_id']].")";
 						$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Downloads-manager details updated by EP4 for ' . $items[$filelayout['v_products_attributes_id']], 'info');
+              }
 					} else { // insert
 						$sql = "INSERT INTO ".TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD." SET 
 							products_attributes_id       = '".$items[$filelayout['v_products_attributes_id']]."',
@@ -239,6 +251,9 @@ if ( isset($_GET['import']) ) {
 							products_attributes_maxdays  = '".$items[$filelayout['v_products_attributes_maxdays']]."',
 							products_attributes_maxcount = '".$items[$filelayout['v_products_attributes_maxcount']]."'";
 						$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Downloads-manager details inserted by EP4 for ' . $items[$filelayout['v_products_attributes_id']], 'info');
+              }
 					}				
 				}
 				$ep_update_count++;			
@@ -279,6 +294,9 @@ if ( isset($_GET['import']) ) {
 					WHERE (
 					stock_id = ".$items[$filelayout['v_stock_id']]." )";
 				$result = ep_4_query($sql);
+          if ($result) {
+            zen_record_admin_activity('Updated products with attributes stock ' . (int)$items[$filelayout['v_stock_id']] . ' via EP4.', 'info');
+          }
 				
 				if ($items[$filelayout['v_products_attributes_filename']] <> '') { // download file name
 					$sql = 'SELECT * FROM '.TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD.' 
@@ -292,6 +310,9 @@ if ( isset($_GET['import']) ) {
 							WHERE ( 
 							products_attributes_id = ".$items[$filelayout['v_products_attributes_id']].")";
 						$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Downloads-manager details updated by EP4 for ' . $items[$filelayout['v_products_attributes_id']], 'info');
+              }
 					} else { // insert
 						$sql = "INSERT INTO ".TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD." SET 
 							products_attributes_id       = '".$items[$filelayout['v_products_attributes_id']]."',
@@ -299,6 +320,9 @@ if ( isset($_GET['import']) ) {
 							products_attributes_maxdays  = '".$items[$filelayout['v_products_attributes_maxdays']]."',
 							products_attributes_maxcount = '".$items[$filelayout['v_products_attributes_maxcount']]."'";
 						$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Downloads-manager details inserted by EP4 for ' . $items[$filelayout['v_products_attributes_id']], 'info');
+              }
 					}				
 				}
 				$ep_update_count++;			
@@ -333,7 +357,7 @@ if ( isset($_GET['import']) ) {
 			//IF STANDARD STOCK, then Update the standard stock
 			if ($items[$filelayout['v_SBA_tracked']] == '') {
 				$sql = "UPDATE ".TABLE_PRODUCTS." SET 
-					products_quantity					    = ".$items[(int)$filelayout['v_products_quantity']] . "
+					products_quantity					    = " . $items[(int)$filelayout['v_products_quantity']] . "
 					WHERE (
 					products_id = ".$items[(int)$filelayout['v_table_tracker']]." )";
 				if ($sync) {
@@ -341,6 +365,7 @@ if ( isset($_GET['import']) ) {
 					//Need to capture all of the product model/product number/quantity counts so that can do a comparison in the SBA section and remove the data point.  Once all done, then cycle through this data and update with it.
 				} elseif (!$sync) { 
 					if ($result = ep_4_query($sql)) {
+            zen_record_admin_activity('Updated product ' . (int)$items[(int)$filelayout['v_table_tracker']] . ' via EP4.', 'info');
 						$ep_update_count++;			
 						$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_UPDATE_PRODUCT, $items[(int)$filelayout['v_products_model']] ) . $items[(int)$filelayout['v_products_quantity']];
 					} else { // error Attribute entry not found - needs work!
@@ -354,6 +379,7 @@ if ( isset($_GET['import']) ) {
 					WHERE (
 					stock_id = ".$items[$filelayout['v_table_tracker']]." )";
 				if ($result = ep_4_query($sql)) {
+          zen_record_admin_activity('Updated products with attributes stock ' . (int)$items[$filelayout['v_table_tracker']] . ' via EP4.', 'info');
 					$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_UPDATE_PRODUCT, $items[(int)$filelayout['v_products_model']]) . $items[(int)$filelayout['v_products_quantity']] . ($ep_4_SBAEnabled == '2' ? " " . $items[(string)$filelayout['v_customid']] : "");
 					$ep_update_count++;			
 					if ($sync) {
@@ -376,6 +402,7 @@ if ( isset($_GET['import']) ) {
 					WHERE (
 					products_id = ".$items[(int)$filelayout['v_table_tracker']]." )";
 				if ($result = ep_4_query($sql)) {
+          zen_record_admin_activity('Updated product ' . (int)$items[(int)$filelayout['v_table_tracker']] . ' via EP4.', 'info');
 					$ep_update_count++;			
 					$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_UPDATE_PRODUCT, $items[(int)$filelayout['v_products_model']] ) . $items[(int)$filelayout['v_products_quantity']];
 				} else { // error Attribute entry not found - needs work!
@@ -405,6 +432,9 @@ if ( isset($_GET['import']) ) {
 					last_modified    = CURRENT_TIMESTAMP " . (array_key_exists('v_sort_order', $filelayout)  ? ", sort_order = " . $items[$filelayout['v_sort_order']] : "" ) . "
 					WHERE (categories_id = ".$items[$filelayout['v_categories_id']].")";
 				$result = ep_4_query($sql);
+          if ($result) {
+            zen_record_admin_activity('Updated category ' . (int)$items[$filelayout['v_categories_id']] . ' via EP4.', 'info');
+          }
 				foreach ($langcode as $key => $lang) {
 					$lid = $lang['id'];
 					// $items[$filelayout['v_categories_name_'.$lid]];
@@ -415,6 +445,9 @@ if ( isset($_GET['import']) ) {
 						WHERE 
 						(categories_id = ".$items[$filelayout['v_categories_id']]." AND language_id = ".$lid.")";
 					$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Updated category description ' . (int)$items[$filelayout['v_categories_id']] . ' via EP4.', 'info');
+            }
 				
 					// $items[$filelayout['v_metatags_title_'.$lid]];
 					// $items[$filelayout['v_metatags_keywords_'.$lid]];
@@ -441,6 +474,9 @@ if ( isset($_GET['import']) ) {
 							language_id 		 = '".$lid."'";
 					}
 					$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Inserted/Updated category metatag information ' . (int)$items[(int)$filelayout['v_categories_id']] . ' via EP4.', 'info');
+            }
 					$ep_update_count++;			
 				} 
 			} else { // error Category ID not Found
@@ -579,8 +615,7 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				$result2 = ep_4_query($sql2);
 						$row2 = ($ep_uses_mysqli ? mysqli_fetch_array($result2) : mysql_fetch_array($result2));
 				$row['v_manufacturers_name'] = $row2['manufacturers_name']; 
-				}
-			else {
+					} else {
 				$row['v_manufacturers_name'] = '';  // added by chadd 4-7-09 - default name to blank
 			}
 			
@@ -790,6 +825,9 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				$sql = "INSERT INTO ".TABLE_MANUFACTURERS." (manufacturers_name, date_added, last_modified)
 					VALUES ('".addslashes($v_manufacturers_name)."', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
 				$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Inserted manufacturer ' . addslashes($v_manufactureres_name) . ' via EP4.', 'info');
+            }
 						$v_manufacturers_id = ($ep_uses_mysqli ? mysqli_insert_id($db->link) : mysql_insert_id()); // id is auto_increment, so can use this function
 				
 				// BUG FIX: TABLE_MANUFACTURERS_INFO need an entry for each installed language! chadd 11-14-2011
@@ -799,6 +837,9 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 					$sql = "INSERT INTO ".TABLE_MANUFACTURERS_INFO." (manufacturers_id, languages_id, manufacturers_url)
 						VALUES ('".addslashes($v_manufacturers_id) . "',".(int)$l_id.",'')"; // seems we are skipping manufacturers url
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Inserted manufacturers info ' . (int)$v_manufacturers_id . ' via EP4.', 'info');
+              }
 				}
 			}
 		} else { // $v_manufacturers_name == '' or name length violation
@@ -896,8 +937,11 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 									categories_id   = '".$thiscategoryid."' AND
 									language_id     = '".$cat_lang_id."'";
 							$result = ep_4_query($sql);
+                  if ($result) {
+                    zen_record_admin_activity('Updated category description ' . (int)$thiscategoryid . ' via EP4.', 'info');
 						}
 					}
+							}
 				} else { // otherwise add new category
 					// get next available categoies_id
 					$sql = "SELECT MAX(categories_id) max FROM ".TABLE_CATEGORIES;
@@ -914,6 +958,9 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 						$max_category_id, '', $theparent_id, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 						)";						
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Inserted category ' . (int)$max_category_id . ' via EP4.', 'info');
+              }
 					// TABLE_CATEGORIES_DESCRIPTION has an entry for EACH installed languag
 					// Check for multiple categories language. If a column is not defined, default to the main language:
 					// categories_name = '".addslashes($thiscategoryname)."'";
@@ -921,18 +968,24 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 					// categories_name = '".addslashes($categories_names_array[$lid][$category_index])."'";
 					foreach ($langcode as $key => $lang2) {
 						$v_categories_name_check = 'v_categories_name_'.$lang2['id']; 
+								if (isset($$v_categories_name_check)) { // update	
 							$cat_lang_id = $lang2['id'];
 							$sql = "INSERT INTO ".TABLE_CATEGORIES_DESCRIPTION." SET 
 								categories_id   = '".$max_category_id."',
 								language_id     = '".$cat_lang_id."', 
-								categories_name = '";
-            if (isset($$v_categories_name_check)) { // update	
-              $sql .= addslashes(ep_4_curly_quotes($categories_names_array[$cat_lang_id][$category_index]))."'";
+										categories_name = '".addslashes(ep_4_curly_quotes($categories_names_array[$cat_lang_id][$category_index]))."'";
 						} else { // column is missing, so default to defined column's value
-							$sql .= addslashes(ep_4_curly_quotes($thiscategoryname))."'";
+									$cat_lang_id = $lang2['id'];
+									$sql = "INSERT INTO ".TABLE_CATEGORIES_DESCRIPTION." SET 
+										categories_id   = '".$max_category_id."',
+										language_id     = '".$cat_lang_id."',
+										categories_name = '".addslashes(ep_4_curly_quotes($thiscategoryname))."'";
 						}	
 						$result = ep_4_query($sql);
+                if ($result) {
+                  zen_record_admin_activity('Inserted category description ' . (int)$max_category_id . ' via EP4.', 'info');
 					}
+							}
 					$thiscategoryid = $max_category_id;
 				}
 				// the current catid is the next level's parent
@@ -957,23 +1010,35 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 						last_modified = CURRENT_TIMESTAMP
 						WHERE artists_id = '".$v_artists_id."'";
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Updated record artist ' . (int)$v_artists_id . ' via EP4.', 'info');
+              }
 					foreach ($langcode as $lang) {
 						$l_id = $lang['id'];
 						$sql = "UPDATE ".TABLE_RECORD_ARTISTS_INFO." SET
 							artists_url = '".addslashes($items[$filelayout['v_artists_url_'.$lid]])."'
 							WHERE artists_id = '".$v_artists_id."' AND languages_id = '".$lid."'"; 
 						$result = ep_4_query($sql);
+                if ($result) {
+                  zen_record_admin_activity('Updated record artist info ' . (int)$v_artists_id . ' via EP4.', 'info');
 					}
+							}
 				} else { // It is set to autoincrement, do not need to fetch max id
 					$sql = "INSERT INTO ".TABLE_RECORD_ARTISTS." (artists_name, artists_image, date_added, last_modified)
 						VALUES ('".addslashes(ep_4_curly_quotes($v_artists_name))."', '".addslashes($v_artists_image)."', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Inserted record artist ' . $addslashes(ep_4_curly_quotes($v_artists_name)) . ' via EP4.', 'info');
+              }
 							$v_artists_id = ($ep_uses_mysqli ? mysqli_insert_id($db->link) : mysql_insert_id()); // id is auto_increment, so can use this function
 					foreach ($langcode as $lang) {
 						$l_id = $lang['id'];
 						$sql = "INSERT INTO ".TABLE_RECORD_ARTISTS_INFO." (artists_id, languages_id, artists_url)
 							VALUES ('".addslashes($v_artists_id)."',".(int)$l_id.",'".addslashes($items[$filelayout['v_artists_url_'.$lid]])."')"; // seems we are skipping manufacturers url
 						$result = ep_4_query($sql);
+                if ($result) {
+                  zen_record_admin_activity('Inserted record artists info ' . (int)$v_artists_id . ' via EP4.', 'info');
+                }
 					}
 				}
 			} else { // $v_artists_name == '' or name length violation
@@ -1000,23 +1065,35 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 						last_modified = CURRENT_TIMESTAMP
 						WHERE record_company_id = '".$v_record_company_id."'";
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Updated record company ' . (int)$v_record_company_id . ' via EP4.', 'info');
+              }
 					foreach ($langcode as $lang) {
 						$l_id = $lang['id'];
 						$sql = "UPDATE ".TABLE_RECORD_COMPANY_INFO." SET
 							record_company_url = '".addslashes($items[$filelayout['v_record_company_url_'.$lid]])."'
 							WHERE record_company_id = '".$v_record_company_id."' AND languages_id = '".$lid."'"; 
 						$result = ep_4_query($sql);
+                if ($result) {
+                  zen_record_admin_activity('Updated record company info ' . (int)$v_record_company_id . ' via EP4.', 'info');
 					}
+							}
 				} else { // It is set to autoincrement, do not need to fetch max id
 					$sql = "INSERT INTO ".TABLE_RECORD_COMPANY." (record_company_name, record_company_image, date_added, last_modified)
 						VALUES ('".addslashes(ep_4_curly_quotes($v_record_company_name))."', '".addslashes($v_record_company_image)."', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Inserted record company ' . addslashes(ep_4_curly_quotes($v_record_company_name)) . ' via EP4.', 'info');
+              }
 							$v_record_company_id = ($ep_uses_mysqli ? mysqli_insert_id($db->link) : mysql_insert_id()); // id is auto_increment, so can use this function
 					foreach ($langcode as $lang) {
 						$l_id = $lang['id'];
 						$sql = "INSERT INTO ".TABLE_RECORD_COMPANY_INFO." (record_company_id, languages_id, record_company_url)
 							VALUES ('".addslashes($v_record_company_id)."',".(int)$l_id.",'".addslashes($items[$filelayout['v_record_company_url_'.$lid]])."')"; // seems we are skipping manufacturers url
 						$result = ep_4_query($sql);
+                if ($result) {
+                  zen_record_admin_activity('Inserted record company info ' . (int)$v_record_company_id . ' via EP4.', 'info');
+                }
 					}
 				}
 			} else { // $v_record_company_name == '' or name length violation
@@ -1042,6 +1119,9 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 					$sql = "INSERT INTO ".TABLE_MUSIC_GENRE." (music_genre_name, date_added, last_modified)
 						VALUES ('".addslashes($v_music_genre_name)."', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Inserted music genre ' . addslashes($v_music_genre_name) . ' via EP4.', 'info');
+              }
 							$v_music_genre_id = ($ep_uses_mysqli ? mysqli_insert_id($db->link) : mysql_insert_id()); // id is auto_increment
 				}
 			} else { // $v_music_genre_name == '' or name length violation
@@ -1135,6 +1215,7 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				$result = ep_4_query($query);
 				if ($result == true) {
 					// need to change to an log file, this is gobbling up memory! chadd 11-14-2011
+              zen_record_admin_activity('New product ' . (int)$v_products_id . ' added via EP4.', 'info');
 					if ($ep_feedback == true) {
 						$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_NEW_PRODUCT, $v_products_model);
 					}
@@ -1149,8 +1230,11 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 								record_company_id	= '".$v_record_company_id."',
 								music_genre_id		= '".$v_music_genre_id."'";
 							$result = ep_4_query($query);
+                  if ($result) {
+                    zen_record_admin_activity('Inserted product music extra ' . (int)$v_products_id . ' via EP4.', 'info');
 						}				
 					}
+							}
 				} else {
 					$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_NEW_PRODUCT_FAIL, $v_products_model);
 					$ep_error_count++;
@@ -1226,6 +1310,7 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				
 				$result = ep_4_query($query);
 				if ($result == true) {
+              zen_record_admin_activity('Updated product ' . (int)$v_products_id . ' via EP4.', 'info');
 					// needs to go into a log file chadd 11-14-2011
 					if ($ep_feedback == true) {
 					$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_UPDATE_PRODUCT, $v_products_model);
@@ -1244,6 +1329,9 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 								music_genre_id		= '".$v_music_genre_id."' 
 								WHERE products_id   = '".$v_products_id."'";
 							$result = ep_4_query($query);
+                  if ($result) {
+                    zen_record_admin_activity('Updated product music extra ' . (int)$v_artists_id . ' via EP4.', 'info');
+                  }
 						}				
 					}					
 					$ep_update_count++;				
@@ -1251,6 +1339,7 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 					$display_output .= sprintf(EASYPOPULATE_4_DISPLAY_RESULT_UPDATE_PRODUCT_FAIL, $v_products_model);
 					$ep_error_count++;
 				}
+
 			}
 			
 			// START: Product MetaTags
@@ -1276,8 +1365,11 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 							language_id = '".$key."'";
 					}
 					$result = ep_4_query($sql);
+              if ($result) {
+                zen_record_admin_activity('Updated/inserted meta tags products description ' . (int)$v_products_id . ' via EP4.', 'info');
 				}
 			} // END: Products MetaTags
+					} // END: Products MetaTags
 		
 			// chadd: use this command to remove all old discount entries.
 			// $db->Execute("delete from ".TABLE_PRODUCTS_DISCOUNT_QUANTITY." where products_id = '".(int)$v_products_id."'");
@@ -1317,7 +1409,10 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 									discount_qty   = '".$$v_discount_qty_var."',
 									discount_price = '".$$v_discount_price_var."'";
 								$result = ep_4_query($sql);
+                  if ($result) {
+                    zen_record_admin_activity('Inserted products discount quantity ' . (int)$v_products_id . ' via EP4.', 'info');
 							} // end: check for empty price
+								} // end: check for empty price
 							$xxx++; 
 							$v_discount_qty_var   = 'v_discount_qty_'.$xxx;
 							$v_discount_price_var = 'v_discount_price_'.$xxx;
@@ -1368,6 +1463,9 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
                         }
                         $sql .= "'" . addslashes($v_products_url[$key]) . "')";
                         $result = ep_4_query($sql);
+                        if ($result) {
+                          zen_record_admin_activity('New product ' . (int)$v_products_id . ' description added via EP4.', 'info');
+                        }
                     } else { // already in the description, update it
                         $sql = "UPDATE ".TABLE_PRODUCTS_DESCRIPTION." SET
        products_name        ='".addslashes($name)."', " .
@@ -1378,6 +1476,9 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
                         $sql .= " products_url='" . addslashes($v_products_url[$key]) . "'
        WHERE products_id = '" . $v_products_id . "' AND language_id = '" . $key . "'";
                         $result = ep_4_query($sql);
+                        if ($result) {
+                          zen_record_admin_activity('Updated product ' . (int)$v_products_id . ' description via EP4.', 'info');
+                        }
                     }
                 }
             } // END: Products Descriptions End	
@@ -1397,6 +1498,9 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 					if (($ep_uses_mysqli ? mysqli_num_rows($result_incategory) : mysql_num_rows($result_incategory)) == 0) { // nope, this is a new category for this product
 					$res1 = ep_4_query('INSERT INTO '.TABLE_PRODUCTS_TO_CATEGORIES.' (products_id, categories_id)
 						VALUES ("'.$v_products_id.'", "'.$v_categories_id.'")');
+            if ($res1) {
+              zen_record_admin_activity('Product ' . (int)$v_products_id . ' copied as link to category ' . (int)$v_categories_id . ' via EP4.', 'info');
+            }
 				} else { // already in this category, nothing to do!
 				}
 			}
@@ -1442,6 +1546,9 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 						'".$v_specials_expires_date."',
 						'1')";
 					$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Inserted special ' . (int)$v_products_id . ' via EP4.', 'info');
+            }
 					$specials_print .= sprintf(EASYPOPULATE_4_SPECIALS_NEW, $v_products_model, substr(strip_tags($v_products_name[$epdlanguage_id]), 0, 10), $v_products_price , $v_specials_price);
 				} else { // existing product
 					if ($v_specials_price == '0') { // delete of existing requested
@@ -1457,7 +1564,10 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 						expires_date				= '".$v_specials_expires_date."',
 						status						= '1'
 						WHERE products_id			= '".(int)$v_products_id."'";
-					ep_4_query($sql);
+						$result = ep_4_query($sql);
+            if ($result) {
+              zen_record_admin_activity('Updated special ' . (int)$v_products_id . ' via EP4.', 'info');
+            }
 					$specials_print .= sprintf(EASYPOPULATE_4_SPECIALS_UPDATE, $v_products_model, substr(strip_tags($v_products_name[$epdlanguage_id]), 0, 10), $v_products_price , $v_specials_price);
 				} // we still have our special here
 			} // end specials for this product
@@ -1481,18 +1591,18 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 	
 	$display_output .= '<h3>Finished Processing Import File</h3>';
 	
-	$display_output .= '<br>Updated records: '.$ep_update_count;
-	$display_output .= '<br>New Imported records: '.$ep_import_count;
-	$display_output .= '<br>Errors Detected: '.$ep_error_count;
-	$display_output .= '<br>Warnings Detected: '.$ep_warning_count;
+		$display_output .= '<br/>Updated records: '.$ep_update_count;
+		$display_output .= '<br/>New Imported records: '.$ep_import_count;
+		$display_output .= '<br/>Errors Detected: '.$ep_error_count;
+		$display_output .= '<br/>Warnings Detected: '.$ep_warning_count;
 	
-	$display_output .= '<br>Memory Usage: '.memory_get_usage(); 
-	$display_output .= '<br>Memory Peak: '.memory_get_peak_usage();
+		$display_output .= '<br/>Memory Usage: '.memory_get_usage(); 
+		$display_output .= '<br/>Memory Peak: '.memory_get_peak_usage();
 	
 	// benchmarking
 	$time_end = microtime(true);
 	$time = $time_end - $time_start;	
-	$display_output .= '<br>Execution Time: '. $time . ' seconds.';
+		$display_output .= '<br/>Execution Time: '. $time . ' seconds.';
 }	
 	
 	// specials status = 0 if date_expires is past.
@@ -1500,9 +1610,10 @@ if ( strtolower(substr($file['name'],0,14)) == "pricebreaks-ep") {
 	if ($has_specials == true) { // specials were in upload so check for expired specials
 		zen_expire_specials();
 	}
-	if (($ep_warning_count > 0) || ($ep_error_count > 0)) 
+	if (($ep_warning_count > 0) || ($ep_error_count > 0)) {
 	$messageStack->add("File Import Completed with issues.", 'warning');
-	else
+	} else {
 	$messageStack->add("File Import Completed.", 'success');
+	}
 } // END FILE UPLOADS
 ?>

--- a/admin/easypopulate_4_import.php
+++ b/admin/easypopulate_4_import.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_import.php, v4.0.25 10-10-2014 mc12345678 $
+// $Id: easypopulate_4_import.php, v4.0.26 10-19-2014 mc12345678 $
 
 // BEGIN: Data Import Module
 if ( isset($_GET['import']) ) {
@@ -402,7 +402,7 @@ if ( isset($_GET['import']) ) {
 				// UPDATE
 				$sql = "UPDATE ".TABLE_CATEGORIES." SET 
 					categories_image = '".addslashes($items[$filelayout['v_categories_image']])."',
-					last_modified    = CURRENT_TIMESTAMP 
+					last_modified    = CURRENT_TIMESTAMP " . (array_key_exists('v_sort_order', $filelayout)  ? ", sort_order = " . $items[$filelayout['v_sort_order']] : "" ) . "
 					WHERE (categories_id = ".$items[$filelayout['v_categories_id']].")";
 				$result = ep_4_query($sql);
 				foreach ($langcode as $key => $lang) {
@@ -921,18 +921,15 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 					// categories_name = '".addslashes($categories_names_array[$lid][$category_index])."'";
 					foreach ($langcode as $key => $lang2) {
 						$v_categories_name_check = 'v_categories_name_'.$lang2['id']; 
-						if (isset($$v_categories_name_check)) { // update	
 							$cat_lang_id = $lang2['id'];
 							$sql = "INSERT INTO ".TABLE_CATEGORIES_DESCRIPTION." SET 
 								categories_id   = '".$max_category_id."',
-								language_id     = '".$cat_lang_id."',
-								categories_name = '".addslashes(ep_4_curly_quotes($categories_names_array[$cat_lang_id][$category_index]))."'";
+								language_id     = '".$cat_lang_id."', 
+								categories_name = '";
+            if (isset($$v_categories_name_check)) { // update	
+              $sql .= addslashes(ep_4_curly_quotes($categories_names_array[$cat_lang_id][$category_index]))."'";
 						} else { // column is missing, so default to defined column's value
-							$cat_lang_id = $lang2['id'];
-							$sql = "INSERT INTO ".TABLE_CATEGORIES_DESCRIPTION." SET 
-								categories_id   = '".$max_category_id."',
-								language_id     = '".$cat_lang_id."',
-								categories_name = '".addslashes(ep_4_curly_quotes($thiscategoryname))."'";
+							$sql .= addslashes(ep_4_curly_quotes($thiscategoryname))."'";
 						}	
 						$result = ep_4_query($sql);
 					}

--- a/admin/includes/auto_loaders/config.zc154_compatibility.php
+++ b/admin/includes/auto_loaders/config.zc154_compatibility.php
@@ -1,0 +1,7 @@
+<?php
+// -----
+// Load the Zen Cart v1.5.4 compatibility module.
+// Copyright (c) 2014 Vinos de Frutas Tropicales
+//
+$autoLoadConfig[65][]  = array ('autoType' => 'init_script',
+                                'loadFile' => 'init_zc154_compatibility.php');

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.27 11-02-2014 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.28 01-03-2015 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -28,7 +28,7 @@ function ep_4_curly_quotes($curly_text) {
 function ep4_zen_field_length($tbl, $fld) {
     global $db;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 
 	$meta = array();
 	$result = ($ep_uses_mysqli ? mysqli_query("SELECT $fld FROM $tbl") : mysql_query("SELECT $fld FROM $tbl"));
@@ -42,7 +42,7 @@ function ep4_zen_field_length($tbl, $fld) {
 
 function ep_4_get_languages() {
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	$langcode = array();
 	$languages_query = ep_4_query("SELECT languages_id, name, code FROM ".TABLE_LANGUAGES." ORDER BY sort_order");
 	$i = 1;
@@ -59,7 +59,7 @@ function ep_4_get_languages() {
 
 function ep_4_SBA1Exists () {
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	// The current thought is to have one of these Exists files for each version of SBA to consider; however, they also all could fall under one SBA_Exists check provided some return is made and a comparison done on the other end about what was returned.  
 	//Check to see if any version of Stock with attributes is installed (If so, and properly programmed, there should be a define for the table associated with the stock.  There may be more than one, and if so, they should all be verified for the particular SBA.
 	if (defined('TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK')) {
@@ -134,6 +134,74 @@ function ep_4_SBA1Exists () {
 		} else {
       return false;
     }
+//		$returnedcols = mysql_fetch_array($colsarray);
+//		$colnames = array_keys($returnedcols);
+/*		echo 'Num Rows: ' . $numCols . '<br />';
+		if ($returnedcols['Field'] == 'stock_id') {
+			echo 'true <br />';
+		} else {
+			echo 'false <br />';
+		}
+		echo '3<br />';
+		echo $returnedcols . '111<br />';
+		print_r($returnedcols);
+		echo '3<br />'; */
+		
+/*		while ($row = mysql_fetch_array($colsarray)){
+			print_r($row);
+			echo '4<br />';
+		}
+		echo '4<br />';*/
+		//return true;
+	} else {
+		return false;
+	}
+}
+
+function ep_4_CEONURIExists () {
+	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
+	// The current thought is to have one of these Exists files for each version of SBA to consider; however, they also all could fall under one SBA_Exists check provided some return is made and a comparison done on the other end about what was returned.  
+	//Check to see if any version of Stock with attributes is installed (If so, and properly programmed, there should be a define for the table associated with the stock.  There may be more than one, and if so, they should all be verified for the particular SBA.
+	if (defined('TABLE_CEON_URI_MAPPINGS')) {
+		//Now that have identified that the table (applicable to mc12345678's store, has been identified as in existence, now need to look at the setup of the table (Number of columns and if each column identified below is in the table, or conversely if the table's column matches the list below.
+		//Columns in table: stock_id, products_id, stock_attributes, quantity, and sort.
+//		echo 'In<br />';
+//		$colsarray = $db->Execute('SHOW COLUMNS FROM ' . TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK);
+		$colsarray = ep_4_query('SHOW COLUMNS FROM ' . TABLE_CEON_URI_MAPPINGS);
+//		echo 'After execute<br />';
+		$numCols = ($ep_uses_mysqli ? mysqli_num_rows($colsarray) : mysql_num_rows($colsarray));
+		if ($numCols == 9) {
+			while ($row = ($ep_uses_mysqli ? mysqli_fetch_array($colsarray) : mysql_fetch_array($colsarray))){
+				switch ($row['Field']) {
+					case 'uri':
+						break;
+					case 'language_id':
+						break;
+					case 'current_uri':
+						break;
+					case 'main_page':
+						break;
+					case 'query_string_parameters':
+						break;
+					case 'associated_db_id':
+						break;
+					case 'alternate_uri':
+						break;
+					case 'redirection_type_code':
+						break;
+					case 'date_added':
+						break;
+					default:
+						return false;
+						break;
+						
+				}
+			}
+			return true;
+		} else {
+			return false;
+		}
 //		$returnedcols = mysql_fetch_array($colsarray);
 //		$colnames = array_keys($returnedcols);
 /*		echo 'Num Rows: ' . $numCols . '<br />';
@@ -828,7 +896,7 @@ if (!function_exists(zen_get_sub_categories)) {
 	function zen_get_sub_categories(&$categories, $categories_id) {
 		global $db;
 		$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-		$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+		$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 		$sub_categories_query = ($ep_uses_mysqli ? mysqli_query($db->link, "SELECT categories_id FROM ".TABLE_CATEGORIES.
 			" WHERE parent_id = '".(int)$categories_id."'") : mysql_query("SELECT categories_id FROM ".TABLE_CATEGORIES.
 			" WHERE parent_id = '".(int)$categories_id."'"));
@@ -882,7 +950,7 @@ function ep_4_get_tax_class_rate($tax_class_id) {
 	global $db;
 	$tax_multiplier = 0;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	 
 	$tax_query = ($ep_uses_mysqli ? mysqli_query($db->link, "SELECT SUM(tax_rate) AS tax_rate FROM ".TABLE_TAX_RATES.
 		" WHERE tax_class_id = '".zen_db_input($tax_class_id)."' GROUP BY tax_priority") : mysql_query("SELECT SUM(tax_rate) AS tax_rate FROM ".TABLE_TAX_RATES.
@@ -898,7 +966,7 @@ function ep_4_get_tax_class_rate($tax_class_id) {
 function ep_4_get_tax_title_class_id($tax_class_title) {
 	global $db;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	$classes_query = ($ep_uses_mysqli ? mysqli_query($db->link, "SELECT tax_class_id FROM ".TABLE_TAX_CLASS.
 		" WHERE tax_class_title = '".zen_db_input($tax_class_title)."'") : mysql_query("SELECT tax_class_id FROM ".TABLE_TAX_CLASS.
 		" WHERE tax_class_title = '".zen_db_input($tax_class_title)."'"));
@@ -934,7 +1002,7 @@ function smart_tags_4($string,$tags,$crsub,$doit) {
 function ep_4_check_table_column($table_name,$column_name) {
 	global $db;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	$sql = "SHOW COLUMNS FROM ".$table_name;
 	$result = ep_4_query($sql);
 	while ($row = ($ep_uses_mysqli ? mysqli_fetch_array($result) : mysql_fetch_array($result))) {
@@ -949,7 +1017,7 @@ function ep_4_check_table_column($table_name,$column_name) {
 function ep_4_remove_product($product_model) {
  	global $db, $ep_debug_logging, $ep_debug_logging_all, $ep_stack_sql_error;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	$sql = "SELECT products_id FROM ".TABLE_PRODUCTS." WHERE products_model = '".zen_db_input($product_model)."'";
 	$products = $db->Execute($sql);
 	if (($ep_uses_mysqli ? mysqli_errno($db->link) : mysql_errno())) {
@@ -1031,7 +1099,7 @@ function write_debug_log_4($string) {
 function ep_4_query($query) {
 	global $ep_debug_logging, $ep_debug_logging_all, $ep_stack_sql_error, $db;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	$result = ($ep_uses_mysqli ? mysqli_query($db->link, $query) : mysql_query($query));
 	if (($ep_uses_mysqli ? mysqli_errno($db->link) : mysql_errno())) {
 		$ep_stack_sql_error = true;
@@ -1073,9 +1141,9 @@ function install_easypopulate_4() {
 			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL),
 			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),')
 		");
-	} elseif (substr($project,0,3) == "1.5") {
+	} elseif (PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.0') {
 		$db->Execute("INSERT INTO ".TABLE_CONFIGURATION_GROUP." (configuration_group_title, configuration_group_description, sort_order, visible) VALUES ('Easy Populate 4', 'Configuration Options for Easy Populate 4', '1', '1')");
-		if (substr($project,0,5) == "1.5.3") {
+		if (PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') {
 			$group_id = mysqli_insert_id($db->link);
 		} else {
 		$group_id = mysql_insert_id();
@@ -1111,7 +1179,7 @@ function install_easypopulate_4() {
 function remove_easypopulate_4() {
 	global $db;
 	$project = PROJECT_VERSION_MAJOR.'.'.PROJECT_VERSION_MINOR;
-	$ep_uses_mysqli = (substr($project, 0, 5) == "1.5.3");
+	$ep_uses_mysqli = ((PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') ? true : false);
 	if ( (substr($project,0,5) == "1.3.8") || (substr($project,0,5) == "1.3.9") ) {
 		$sql = "SELECT configuration_group_id FROM ".TABLE_CONFIGURATION_GROUP." WHERE configuration_group_title = 'Easy Populate 4' LIMIT 1";
 		$result = ep_4_query($sql);
@@ -1172,4 +1240,3 @@ function register_globals_vars_check_4 () {
 	global $HTTP_POST_FILES;
 	print "HTTP_POST_FILES: "; print_r($HTTP_POST_FILES); echo '<br />';
 }
-?>

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.26 10-19-2014 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.27 11-02-2014 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -340,6 +340,7 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			p.products_date_added			as v_date_added,
 			p.products_tax_class_id			as v_tax_class_id,
 			p.products_quantity				as v_products_quantity,
+			p.master_categories_id				as v_master_categories_id,
 			p.manufacturers_id				as v_manufacturers_id,
 			subc.categories_id				as v_categories_id,
 			p.products_status				as v_status,
@@ -1069,7 +1070,8 @@ function install_easypopulate_4() {
 			('Convert Character 0x92',             'EASYPOPULATE_4_CONFIG_CHAR_92', '1', 'Convert Character 0x92 characters in Product Names &amp; Descriptions (default 1).<br><br>0=No Change<br>1=Replace with Standard Single Quote<br>2=Replace with HMTL equivalant', ".$group_id.", '15', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\", \"2\"),'),
 			('Enable Products Meta Data',          'EASYPOPULATE_4_CONFIG_META_DATA', '1', 'Enable Products Meta Data Columns (default 1).<br><br>0=Disable<br>1=Enable', ".$group_id.", '16', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'), 
 			('Enable Products Music Data',         'EASYPOPULATE_4_CONFIG_MUSIC_DATA', '0', 'Enable Products Music Data Columns (default 0).<br><br>0=Disable<br>1=Enable', ".$group_id.", '17', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
-			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL)
+			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL),
+			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),')
 		");
 	} elseif (substr($project,0,3) == "1.5") {
 		$db->Execute("INSERT INTO ".TABLE_CONFIGURATION_GROUP." (configuration_group_title, configuration_group_description, sort_order, visible) VALUES ('Easy Populate 4', 'Configuration Options for Easy Populate 4', '1', '1')");
@@ -1098,7 +1100,8 @@ function install_easypopulate_4() {
 			('Convert Character 0x92',             'EASYPOPULATE_4_CONFIG_CHAR_92', '1', 'Convert Character 0x92 characters in Product Names &amp; Descriptions (default 1).<br><br>0=No Change<br>1=Replace with Standard Single Quote<br>2=Replace with HMTL equivalant', ".$group_id.", '15', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\", \"2\"),'),
 			('Enable Products Meta Data',          'EASYPOPULATE_4_CONFIG_META_DATA', '1', 'Enable Products Meta Data Columns (default 1).<br><br>0=Disable<br>1=Enable', ".$group_id.", '16', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'), 
 			('Enable Products Music Data',         'EASYPOPULATE_4_CONFIG_MUSIC_DATA', '0', 'Enable Products Music Data Columns (default 0).<br><br>0=Disable<br>1=Enable', ".$group_id.", '17', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
-			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL)
+			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL),
+			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),')
 		");
 	} else { // unsupported version 
 		// i should do something here!

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.25 10-10-2014 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.26 10-19-2014 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -486,7 +486,7 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		$filelayout = array();
 		$filelayout[] = 'v_categories_id';
 		$filelayout[] = 'v_categories_image';
-		foreach ($langcode as $key => $lang) { // create categories variables for each language id
+    foreach ($langcode as $key => $lang) { // create categories variables for each language id
 			$l_id = $lang['id'];
 			$filelayout[] = 'v_categories_name_'.$l_id;
 			$filelayout[] = 'v_categories_description_'.$l_id;
@@ -497,9 +497,11 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			$filelayout[]   = 'v_metatags_keywords_'.$l_id;
 			$filelayout[]   = 'v_metatags_description_'.$l_id;
 		} 
+    $filelayout[] = 'v_sort_order';
 		$filelayout_sql = 'SELECT
 			c.categories_id    AS v_categories_id,
-			c.categories_image AS v_categories_image
+			c.categories_image AS v_categories_image,
+      c.sort_order    as v_sort_order
 			FROM '
 			.TABLE_CATEGORIES.' AS c';
 		break;

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.23 07-13-2014 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.25 10-10-2014 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -97,10 +97,43 @@ function ep_4_SBA1Exists () {
 				}
 				echo '3<br />'; */
 			}
-			return true;
+			return '1';
+		} elseif ($numCols >= 6) {
+      $desired = 0;
+      $addToList = array();
+			while ($row = ($ep_uses_mysqli ? mysqli_fetch_array($colsarray) : mysql_fetch_array($colsarray))){
+				switch ($row['Field']) {
+					case 'stock_id':
+            $desired++;
+            break;
+					case 'products_id':
+            $desired++;
+						break;
+					case 'stock_attributes':
+            $desired++;
+						break;
+					case 'quantity':
+            $desired++;
+						break;
+					case 'sort':
+            $desired++;
+						break;
+          case 'customid';
+            $desired++;
+            break;
+          default:
+            $addToList = $row['Field'];
+            break;
+				}
+      }
+      if ($desired >= 6) {
+        return '2';
+      } else {
+        return false;
+      }
 		} else {
-			return false;
-		}
+      return false;
+    }
 //		$returnedcols = mysql_fetch_array($colsarray);
 //		$colnames = array_keys($returnedcols);
 /*		echo 'Num Rows: ' . $numCols . '<br />';
@@ -138,7 +171,11 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			if ($ep_supported_mods['psd'] == true) { // products short description mod
 				$filelayout[] = 'v_products_short_desc_'.$l_id;
 			}
-		} 
+		}
+   	$ep_4_SBAEnabled = ep_4_SBA1Exists();
+    if ($ep_4_SBAEnabled == '2') {
+      $filelayout[] = 'v_customid';
+    }
 		//$filelayout[] =	'v_products_options_values_name'; // options values name from table PRODUCTS_OPTIONS_VALUES
 		$filelayout[] = 'v_SBA_tracked';
 		$filelayout[] = 'v_table_tracker';
@@ -605,8 +642,12 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		$filelayout[] =	'v_stock_attributes'; 
 		$filelayout[] =	'v_products_model'; // product model from table PRODUCTS
 		$filelayout[] =	'v_quantity';
+   	$ep_4_SBAEnabled = ep_4_SBA1Exists();
+    if ($ep_4_SBAEnabled == '2') {
+      $filelayout[] = 'v_customid';
+    }
 		$filelayout[] =	'v_sort';
-		$filelayout[] =	'v_products_name'; // product model from table PRODUCTS
+		$filelayout[] =	'v_products_name'; // product name from table PRODUCTS
 		$filelayout[] =	'v_products_options_name'; // options name from table PRODUCTS_OPTIONS
 		$filelayout[] =	'v_products_options_values_name'; // options values name from table PRODUCTS_OPTIONS_VALUES
 		$filelayout[] =	'v_products_attributes_id';
@@ -687,8 +728,9 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			s.stock_attributes				 as v_stock_attributes,
 			s.quantity					 as v_quantity,
 			s.sort						 as v_sort,
-			pd.products_name				 as v_products_name
-			FROM '
+			pd.products_name				 as v_products_name' . ( $ep_4_SBAEnabled == '2' ? ',
+        s.customid            as v_customid ' : ' ') .
+				'FROM '
 			.TABLE_PRODUCTS_ATTRIBUTES.     ' as a,'
 			.TABLE_PRODUCTS.                ' as p,'
 			.TABLE_PRODUCTS_OPTIONS.        ' as o,'

--- a/admin/includes/init_includes/init_zc154_compatibility.php
+++ b/admin/includes/init_includes/init_zc154_compatibility.php
@@ -1,0 +1,21 @@
+<?php
+// -----
+// Common Module (used by many plugins) to provide downward compatibility to Zen Cart v1.5.4 admin-level changes.
+// Copyright (c) 2014 Vinos de Frutas Tropicales
+//
+if (!defined('IS_ADMIN_FLAG')) {
+    die('Illegal Access');
+}
+// -----
+// This plugin uses a Zen Cart v1.5.4 "core-file base".  One or more files overwritten for this plugin make
+// use of a function (zen_record_admin_activity) that was introduced in Zen Cart v1.5.4.  That function (present in
+// /admin/includes/classes/class.admin.zcObserverLogEventListener.php) loads at checkpoint 65.
+//
+// This init-file, also loaded at CP-65, provides the definition for the zen_record_admin_activity function IF IT IS
+// NOT PREVIOUSLY DEFINED.  That way, the various functions in the overwritten core files will have their function-interface
+// satisfied.
+//
+if (!function_exists ('zen_record_admin_activity')) {
+  function zen_record_admin_activity ($message, $severity) {
+  }
+}

--- a/changelog.txt
+++ b/changelog.txt
@@ -161,3 +161,7 @@
 					use the customid field.  The detailed export was updated; 
 					however, removal of old SBA records still needs to be
 					addressed.  Updated the README text a little.
+4.0.26   10-19-2014      Added the sort_id associated with categories.  Import and Export are
+                         through the Categories Only (with Metatags) file(s).  If column is present
+                         then the sort_id will be modified accordingly.  If the column is absent
+                         there will be no change of the category's sort_order.

--- a/changelog.txt
+++ b/changelog.txt
@@ -177,4 +177,9 @@
 					the active uri is provided by that code.  Other URI rewriters may provide
 					the same functionality when installed and active; however, that has not
 					been tested.
-					
+4.0.28   01-03-2015      Added bypass to mb_internal_string and notification.
+					Also modified version check to support ZC 1.5.4 and above.
+					Future versions of ZC may still require this to be revised, but at least
+					this program will not need to be updated merely to support a version check.
+					Incorporated admin logging of database inserts and updates similar (and beyond)
+					those contained in ZC 1.5.4.  Deletions were not incorporated.

--- a/changelog.txt
+++ b/changelog.txt
@@ -165,3 +165,16 @@
                          through the Categories Only (with Metatags) file(s).  If column is present
                          then the sort_id will be modified accordingly.  If the column is absent
                          there will be no change of the category's sort_order.
+4.0.26a  10-25-2014      Corrected the display of the SBA options.  Previously SBA menu options
+					displayed for all users not just those that had SBA installed.  This was
+					the only modification made to this version.
+4.0.26b  10-26-2014		Added a menu display of the status of SBA being installed similar to other
+					options previously incorporated by chadderruski (such as products short
+					descriptions, product unit of measure, etc...) Also updated some of the
+					html formatting.
+4.0.27   10-27-2014      Provided export of product and category URIs as generated from the admin
+					function zen_catalog_href_link.  If CEON URI Mapping is installed, then
+					the active uri is provided by that code.  Other URI rewriters may provide
+					the same functionality when installed and active; however, that has not
+					been tested.
+					

--- a/changelog.txt
+++ b/changelog.txt
@@ -154,3 +154,10 @@
 					of the basic file.
 4.0.24   07-15-2014 Fixed typo in attribute import (missing $ on variable name), and also corrected the way index increment was
 					calculated.
+4.0.25   10-10-2014		Added capability of using EP4 with modifications shown 
+					in potteryhouse's version of SBA. (Recognizes customid column).
+					This may also open EP4 to other versions of SBA; however, 
+					this code has not been tested on other versions of SBA that 
+					use the customid field.  The detailed export was updated; 
+					however, removal of old SBA records still needs to be
+					addressed.  Updated the README text a little.


### PR DESCRIPTION
Added functionality to support potteryhouse's version of SBA, which may also open operation to a few other
SBA versions.  This specifically added the customid to the export/import.  Other fields remain to be considered; however, the SBA is still in a state of flux.  Also updated some of the SBA related functions to support ZC 1.5.3. as they were not updated previously.