### PR TITLE
Update to master to V4.0.30

### DIFF
--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4.php, v4.0.28 01-03-2015 mc12345678 $
+// $Id: easypopulate_4.php, v4.0.29 04-03-2015 mc12345678 $
 
 // CSV VARIABLES - need to make this configurable in the ADMIN
 // $csv_delimiter = "\t"; // "\t" = tab AND "," = COMMA
@@ -47,7 +47,7 @@ $ep_debug_logging_all = false; // do not comment out.. make false instead
 /* Test area end */
 
 // Current EP Version - Modded by Chadd
-$curver              = '4.0.28 - Beta 01-03-2015';
+$curver              = '4.0.29 - Beta 04-03-2015';
 $display_output      = ''; // results of import displayed after script run
 $ep_dltype           = NULL;
 $ep_stack_sql_error  = false; // function returns true on any 1 error, and notifies user of an error
@@ -58,7 +58,7 @@ $has_specials        = false;
 $ep_supported_mods = array();
 
 // default smart-tags setting when enabled. This can be added to.
-$smart_tags = array("\r\n|\r|\n" => '<br/>', ); // need to check into this more
+$smart_tags = array("\r\n|\r|\n" => '<br />', ); // need to check into this more
 
 if (substr($tempdir, -1) != '/') $tempdir .= '/';
 if (substr($tempdir, 0, 1) == '/') $tempdir = substr($tempdir, 1);
@@ -99,8 +99,11 @@ $ep_supported_mods['uom'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_pri
 $ep_supported_mods['upc'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_upc');       // upc = UPC Code, added by Chadd
 $ep_supported_mods['gpc'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_gpc'); // gpc = google product category for Google Merchant Center, added by Chadd 10-1-2011
 $ep_supported_mods['msrp'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_msrp'); // msrp = manufacturer's suggested retail price, added by Chadd 1-9-2012
+$ep_supported_mods['map'] = ep_4_check_table_column(TABLE_PRODUCTS,'map_enabled');
+$ep_supported_mods['map'] = ($ep_supported_mods['map'] && ep_4_check_table_column(TABLE_PRODUCTS, 'map_price'));
 $ep_supported_mods['gppi'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_group_a_price'); // gppi = group pricing per item, added by Chadd 4-24-2012
 $ep_supported_mods['excl'] = ep_4_check_table_column(TABLE_PRODUCTS,'products_exclusive'); // exclu = Custom Mod for Exclusive Products: 04-24-2012
+$ep_supported_mods['dual'] = ep_4_check_table_column(TABLE_PRODUCTS_ATTRIBUTES, 'options_values_price_w');
 // END: check for existance of various mods
 
 // custom products fields check
@@ -272,13 +275,13 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 	<?php 	echo zen_draw_separator('pixel_trans.gif', '1', '10'); ?>
 	<div class="pageHeading"><?php echo "Easy Populate $curver"; ?></div>
     
-	<div style="text-align:right; float:right; width:25%"><a href="<?php echo zen_href_link(FILENAME_EASYPOPULATE_4, 'epinstaller=remove') ?>">Un-Install EP4</a>
+	<div style="text-align:right; float:right; width:25%"><a href="<?php echo zen_href_link(FILENAME_EASYPOPULATE_4, 'epinstaller=remove') ?>"><?php echo EASYPOPULATE_4_REMOVE_SETTINGS; ?></a>
     <?php
-		echo '<br/><b><u>Configuration Settings</u></b><br/>';
-		echo 'Upload Directory: <b>'.$tempdir.'</b><br/>'; 
+		echo '<br/><b><u>' . EASYPOPULATE_4_CONFIG_SETTINGS . '</u></b><br/>';
+		echo EASYPOPULATE_4_CONFIG_UPLOAD . '<b>'.$tempdir.'</b><br/>'; 
 		echo 'Verbose Feedback: '.(($ep_feedback) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
-		echo 'Split Records: '.$ep_split_records.'<br/>';
-		echo 'Execution Time: '.$ep_execution.'<br/>';
+		echo EASYPOPULATE_4_DISPLAY_SPLIT_SHORT . $ep_split_records.'<br/>';
+		echo EASYPOPULATE_4_DISPLAY_EXEC_TIME . $ep_execution.'<br/>';
 		switch ($ep_curly_quotes) {
 			case 0:
 			$ep_curly_text = "No Change";
@@ -303,8 +306,8 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 		}
 		echo 'Convert Curly Quotes: '.$ep_curly_text.'<br/>';
 		echo 'Convert Char 0x92: '.$ep_char92_text.'<br/>';
-		echo 'Enable Products Metatags: '.$ep_metatags.'<br/>';
-		echo 'Enable Products Music: '.$ep_music.'<br/>';
+		echo EASYPOPULATE_4_DISPLAY_ENABLE_META.$ep_metatags.'<br/>';
+		echo EASYPOPULATE_4_DISPLAY_ENABLE_MUSIC.$ep_music.'<br/>';
 			
 		echo '<br/><b><u>Custom Products Fields</u></b><br/>';
 		echo 'Product Short Descriptions: '.(($ep_supported_mods['psd']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
@@ -313,11 +316,12 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 		// Google Product Category for Google Merchant Center
 		echo 'Google Product Category: '.(($ep_supported_mods['gpc']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 		echo "Manufacturer's Suggested Retail Price: ".(($ep_supported_mods['msrp']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
-		echo "Group Pricing Per Item: ".(($ep_supported_mods['gppi']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+    echo "Manufacturer's Advertised Price: ".(($ep_supported_mods['map']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
+    echo "Group Pricing Per Item: ".(($ep_supported_mods['gppi']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 		echo "Exclusive Products Mod: ".(($ep_supported_mods['excl']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
  		echo "Stock By Attributes Mod: ".(($ep_4_SBAEnabled != false) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
     echo "CEON URI Rewriter Mod: " . (($ep4CEONURIDoesExist == true) ? '<font color="green">TRUE</font>' : "FALSE") . '<br/>';
-
+    echo "Dual Pricing Mod: " . (($ep_supported_mods['dual']) ? '<font color="green">TRUE</font>':"FALSE").'<br/>';
 
 		echo "<br/><b><u>User Defined Products Fields: </b></u><br/>";
 		$i = 0;
@@ -522,11 +526,11 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
 <?php
 	echo $display_output; // upload results
 	if (strlen($specials_print) > strlen(EASYPOPULATE_4_SPECIALS_HEADING)) {
-		echo '<br/>' . $specials_print . EASYPOPULATE_4_SPECIALS_FOOTER; // specials summary
+		echo '<br />' . $specials_print . EASYPOPULATE_4_SPECIALS_FOOTER; // specials summary
 	}	
 ?>
 </div>
-<br/>
+<br />
 <?php require(DIR_WS_INCLUDES . 'footer.php'); ?>
 </body>
 </html>

--- a/admin/easypopulate_4_import.php
+++ b/admin/easypopulate_4_import.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_import.php, v4.0.28 01-03-2015 mc12345678 $
+// $Id: easypopulate_4_import.php, v4.0.29 04-03-2015 mc12345678 $
 
 // BEGIN: Data Import Module
 if ( isset($_GET['import']) ) {
@@ -35,6 +35,10 @@ if ( isset($_GET['import']) ) {
 	if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 		$default_these[] = 'v_products_msrp';
 	}
+  if ($ep_supported_mods['map'] == true) { // Manufacturer's Advertised Price
+    $default_these[] = 'v_map_enabled';
+    $default_these[] = 'v_map_price';
+  }
 	if ($ep_supported_mods['gppi'] == true) { // Group Pricing Per Item - 4-24-2012
 		$default_these[] = 'v_products_group_a_price';
 		$default_these[] = 'v_products_group_b_price';
@@ -197,6 +201,12 @@ if ( isset($_GET['import']) ) {
 				// UPDATE
 				$sql = "UPDATE ".TABLE_PRODUCTS_ATTRIBUTES." SET 
 					options_values_price              = ".$items[$filelayout['v_options_values_price']].",
+					";
+        if ($ep_supported_mods['dual']) {
+          $sql .= "options_values_price_w              = ".$items[$filelayout['v_options_values_price_w']].",";
+        }
+
+        $sql .= "
 					price_prefix                      = '".$items[$filelayout['v_price_prefix']]."',
 					products_options_sort_order       = ".$items[$filelayout['v_products_options_sort_order']].",
 					product_attribute_is_free         = ".$items[$filelayout['v_product_attribute_is_free']].",
@@ -289,7 +299,7 @@ if ( isset($_GET['import']) ) {
 					stock_attributes                  = '".$items[$filelayout['v_stock_attributes']]."',
 					quantity					    = ".$items[$filelayout['v_quantity']].",
 					sort						    = ".$items[$filelayout['v_sort']]. ( $ep_4_SBAEnabled == '2' ? ",
-          customid            = ".$items[$filelayout['v_customid']] : " ") .
+          customid            = '" . $items[$filelayout['v_customid']] . "' " : " ") .
 				"
 					WHERE (
 					stock_id = ".$items[$filelayout['v_stock_id']]." )";
@@ -518,6 +528,10 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 		if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 			$sql .= 'p.products_msrp as v_products_msrp,';
 		}
+    if ($ep_supported_mods['map'] == true) { // Manufacturer's Advertised Price
+      $sql .= 'p.map_enabled as v_map_enabled,';
+      $sql .= 'p.map_price as v_map_price,';
+    }
 		if ($ep_supported_mods['gppi'] == true) { // Group Pricing Per Item
 			$sql .= 'p.products_group_a_price as v_products_group_a_price,';
 			$sql .= 'p.products_group_b_price as v_products_group_b_price,';
@@ -586,7 +600,7 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 			foreach ($langcode as $key => $lang) {
 				$sql2 = 'SELECT * FROM '.TABLE_PRODUCTS_DESCRIPTION.' WHERE products_id = '.$row['v_products_id'].' AND language_id = '.$lang['id'];
 				$result2 = ep_4_query($sql2);
-						$row2 = ($ep_uses_mysqli ? mysqli_fetch_array($result) : mysql_fetch_array($result2));
+						$row2 = ($ep_uses_mysqli ? mysqli_fetch_array($result2) : mysql_fetch_array($result2));
 				// create variables (v_products_name_1, v_products_name_2, etc. which corresponds to our column headers) and assign data
 				$row['v_products_name_'.$lang['id']] = ep_4_curly_quotes($row2['products_name']);
 				
@@ -1173,6 +1187,10 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 					$query .= "products_msrp = '".$v_products_msrp."',";
 				}
+        if ($ep_supported_mods['map'] == true) { // Manufacturer's Advertised Price
+          $query .= "map_enabled = '".$v_map_enabled."',";
+          $query .= "map_price = '".$v_map_price."',";
+        }
 				if ($ep_supported_mods['gppi'] == true) { // Group Pricing Per Item
 					$query .= "products_group_a_price = '".$v_products_group_a_price."',";
 					$query .= "products_group_b_price = '".$v_products_group_b_price."',";
@@ -1269,6 +1287,10 @@ if ( ( strtolower(substr($file['name'],0,15)) <> "categorymeta-ep") && ( strtolo
 				if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 					$query .= "products_msrp = '".$v_products_msrp."',";
 				}
+        if ($ep_supported_mods['map'] == true) { // Manufacturer's Advertised Price
+          $query .= "map_enabled = '".$v_map_enabled."',";
+          $query .= "map_price = '".$v_map_price."',";
+        }
 				if ($ep_supported_mods['gppi'] == true) { // Group Pricing Per Item
 					$query .= "products_group_a_price = '".$v_products_group_a_price."',";
 					$query .= "products_group_b_price = '".$v_products_group_b_price."',";

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.29 04-03-2015 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.30 06-27-2015 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -1178,14 +1178,15 @@ function install_easypopulate_4() {
 			('Enable Products Meta Data',          'EASYPOPULATE_4_CONFIG_META_DATA', '1', 'Enable Products Meta Data Columns (default 1).<br><br>0=Disable<br>1=Enable', ".$group_id.", '16', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'), 
 			('Enable Products Music Data',         'EASYPOPULATE_4_CONFIG_MUSIC_DATA', '0', 'Enable Products Music Data Columns (default 0).<br><br>0=Disable<br>1=Enable', ".$group_id.", '17', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
 			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL),
-			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),')
+			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
+			('Show all EP4 Filetypes with Files',       'EP4_SHOW_ALL_FILETYPES', 'True', 'When looking at the EP4 Tools screen, should the filename prefix for all specific file types be displayed for all possible file types (True [default]), should only the method(s) that will be used to process the files present be displayed (False), or should there be no assistance be provided on filenaming on the main page (Hidden) like it was until this feature was added? (True, False, or Hidden)', ".$group_id.", '25', NULL, now(), NULL, 'zen_cfg_select_option(array(\"True\", \"False\", \"Hidden\"),')
 		");
 	} elseif (PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.0') {
 		$db->Execute("INSERT INTO ".TABLE_CONFIGURATION_GROUP." (configuration_group_title, configuration_group_description, sort_order, visible) VALUES ('Easy Populate 4', 'Configuration Options for Easy Populate 4', '1', '1')");
 		if (PROJECT_VERSION_MAJOR > '1' || PROJECT_VERSION_MINOR >= '5.3') {
 			$group_id = mysqli_insert_id($db->link);
 		} else {
-		$group_id = mysql_insert_id();
+    	$group_id = mysql_insert_id();
 		}
 		$db->Execute("UPDATE ".TABLE_CONFIGURATION_GROUP." SET sort_order = ".$group_id." WHERE configuration_group_id = ".$group_id);
 		
@@ -1208,7 +1209,8 @@ function install_easypopulate_4() {
 			('Enable Products Meta Data',          'EASYPOPULATE_4_CONFIG_META_DATA', '1', 'Enable Products Meta Data Columns (default 1).<br><br>0=Disable<br>1=Enable', ".$group_id.", '16', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'), 
 			('Enable Products Music Data',         'EASYPOPULATE_4_CONFIG_MUSIC_DATA', '0', 'Enable Products Music Data Columns (default 0).<br><br>0=Disable<br>1=Enable', ".$group_id.", '17', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
 			('User Defined Products Fields',       'EASYPOPULATE_4_CONFIG_CUSTOM_FIELDS', '', 'User Defined Products Table Fields (comma delimited, no spaces)', ".$group_id.", '18', NULL, now(), NULL, NULL),
-			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),')
+			('Export URI with Prod and or Cat',       'EASYPOPULATE_4_CONFIG_EXPORT_URI', '0', 'Export the current products or categories URI when exporting data? (Yes - 1 or no - 0)', ".$group_id.", '19', NULL, now(), NULL, 'zen_cfg_select_option(array(\"0\", \"1\"),'),
+			('Show all EP4 Filetypes with Files',       'EP4_SHOW_ALL_FILETYPES', 'True', 'When looking at the EP4 Tools screen, should the filename prefix for all specific file types be displayed for all possible file types (True [default]), should only the method(s) that will be used to process the files present be displayed (False), or should there be no assistance be provided on filenaming on the main page (Hidden) like it was until this feature was added? (True, False, or Hidden)', ".$group_id.", '25', NULL, now(), NULL, 'zen_cfg_select_option(array(\"True\", \"False\", \"Hidden\"),')
 		");
 	} else { // unsupported version 
 		// i should do something here!

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1,5 +1,5 @@
 <?php
-// $Id: easypopulate_4_functions.php, v4.0.28 01-03-2015 mc12345678 $
+// $Id: easypopulate_4_functions.php, v4.0.29 04-03-2015 mc12345678 $
 
 function ep_4_curly_quotes($curly_text) {
 	$ep_curly_quotes = (int)EASYPOPULATE_4_CONFIG_CURLY_QUOTES;
@@ -300,7 +300,11 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['msrp'] == true) { // Requested Mod Support - Manufacturer's Suggest Retail Price
 			$filelayout[] = 'v_products_msrp'; 
 		}
-		if ($ep_supported_mods['gppi'] == true) { // Requested Mod Support - Group Pricing Per Item
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout[] = 'v_map_enabled';
+      $filelayout[] = 'v_map_price';
+    }
+    if ($ep_supported_mods['gppi'] == true) { // Requested Mod Support - Group Pricing Per Item
 			$filelayout[] = 'v_products_group_a_price';
 			$filelayout[] = 'v_products_group_b_price';
 			$filelayout[] = 'v_products_group_c_price';
@@ -383,6 +387,10 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['msrp'] == true) { // Requested Mod Support - Manufacturer's Suggest Retail Price
 			$filelayout_sql .=  'p.products_msrp as v_products_msrp,'; 
 		}	
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout_sql .= 'p.map_enabled as v_map_enabled,';
+      $filelayout_sql .= 'p.map_price as v_map_price,';
+    }
 		if ($ep_supported_mods['gppi'] == true) { // Requested Mod Support - Group Pricing Per Item
 			$filelayout_sql .=  'p.products_group_a_price as v_products_group_a_price,';
 			$filelayout_sql .=  'p.products_group_b_price as v_products_group_b_price,';
@@ -464,6 +472,10 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 			$filelayout[] = 'v_products_msrp'; 
 		}
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout[] = 'v_map_enabled';
+      $filelayout[] = 'v_map_price';
+    }
 		$filelayout[] = 'v_products_quantity';
 		$filelayout_sql = 'SELECT
 			p.products_id     as v_products_id,
@@ -475,6 +487,13 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['uom'] == true) { // price UOM mod
 			$filelayout_sql .= 'p.products_price_uom as v_products_price_uom,';
 		}
+		if ($ep_supported_mods['msrp'] == true) { // Requested Mod Support - Manufacturer's Suggest Retail Price
+			$filelayout_sql .=  'p.products_msrp as v_products_msrp,'; 
+		}	
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout_sql .= 'p.map_enabled as v_map_enabled,';
+      $filelayout_sql .= 'p.map_price as v_map_price,';
+    }
 		$filelayout_sql .= 'p.products_tax_class_id as v_tax_class_id,
 			p.products_quantity as v_products_quantity
 			FROM '		
@@ -497,6 +516,10 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['msrp'] == true) { // Manufacturer's Suggested Retail Price
 			$filelayout[] = 'v_products_msrp'; 
 		}
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout[] = 'v_map_enabled';
+      $filelayout[] = 'v_map_price';
+    }
 		$filelayout[] =	'v_products_discount_type';
 		$filelayout[] =	'v_products_discount_type_from';
 		// discount quantities base on $max_qty_discounts	
@@ -516,6 +539,13 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		if ($ep_supported_mods['uom'] == true) { // price UOM mod
 			$filelayout_sql .= 'p.products_price_uom as v_products_price_uom,';
 		}
+		if ($ep_supported_mods['msrp'] == true) { // Requested Mod Support - Manufacturer's Suggest Retail Price
+			$filelayout_sql .=  'p.products_msrp as v_products_msrp,'; 
+		}	
+		if ($ep_supported_mods['map'] == true) { // Requested Mod Support - Manufacturer's Advertised Price
+      $filelayout_sql .= 'p.map_enabled as v_map_enabled,';
+      $filelayout_sql .= 'p.map_price as v_map_price,';
+    }
 		$filelayout_sql .= 'p.products_discount_type as v_products_discount_type,
 			p.products_discount_type_from as v_products_discount_type_from
 			FROM '
@@ -585,6 +615,9 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 		$filelayout[] =	'v_options_values_id';
 		$filelayout[] =	'v_products_options_values_name'; // options values name from table PRODUCTS_OPTIONS_VALUES
 		$filelayout[] =	'v_options_values_price';
+    if ($ep_supported_mods['dual']) {
+      $filelayout[] = 'v_options_values_price_w';
+    }
 		$filelayout[] =	'v_price_prefix';
 		$filelayout[] =	'v_products_options_sort_order';
 		$filelayout[] =	'v_product_attribute_is_free';
@@ -629,7 +662,13 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			a.options_values_id                 as v_options_values_id,
 			v.products_options_values_id        as v_products_options_values_id,
 			v.products_options_values_name      as v_products_options_values_name,
-			a.options_values_price              as v_options_values_price,
+			a.options_values_price              as v_options_values_price, ';
+    if ($ep_supported_mods['dual']) {
+$filelayout_sql .= '
+      a.options_values_price_w            as v_options_values_price_w,
+      ';
+    }
+$filelayout_sql .= '
 			a.price_prefix                      as v_price_prefix,
 			a.products_options_sort_order       as v_products_options_sort_order,
 			a.product_attribute_is_free         as v_product_attribute_is_free,

--- a/admin/includes/languages/deutsche/easypopulate_4.php
+++ b/admin/includes/languages/deutsche/easypopulate_4.php
@@ -64,12 +64,12 @@ define('EASYPOPULATE_4_SPECIALS_FOOTER', '</p>'); // close paragraph
 // error log defines - for ep_debug_log.txt
 define('EASYPOPULATE_4_ERRORLOG_SQL_ERROR', 'MySQL error %s: %s\nWhen executing:\n%sn');
 
-define('EASYPOPULATE_4_REMOVE_SETTINGS', 'Un-Install EP4');
-define('EASYPOPULATE_4_CONFIG_SETTINGS', 'Configuration Settings');
-define('EASYPOPULATE_4_CONFIG_UPLOAD', 'Upload Directory: ');
-define('EASYPOPULATE_4_DISPLAY_SPLIT_SHORT', 'Split Records: ');
-define('EASYPOPULATE_4_DISPLAY_EXEC_TIME', 'Execution Time: ');
-define('EASYPOPULATE_4_DISPLAY_ENABLE_META', 'Enable Products Metatags: ');
-define('EASYPOPULATE_4_DISPLAY_ENABLE_MUSIC', 'Enable Products Music: ');
+define('EASYPOPULATE_4_REMOVE_SETTINGS', 'Easy Populate 4 deinstallieren' );
+define('EASYPOPULATE_4_CONFIG_SETTINGS', 'Konfigurationseinstellungen');
+define('EASYPOPULATE_4_CONFIG_UPLOAD', 'Upload Verzeichnis: ');
+define('EASYPOPULATE_4_DISPLAY_SPLIT_SHORT', 'Einträge aufteilen: ');
+define('EASYPOPULATE_4_DISPLAY_EXEC_TIME', 'Ausführungszeit: ');
+define('EASYPOPULATE_4_DISPLAY_ENABLE_META', 'Metatags der Artikel aktivieren:  ');
+define('EASYPOPULATE_4_DISPLAY_ENABLE_MUSIC', 'Artikeltyp Musik aktivieren: ');
 
 ?>

--- a/admin/includes/languages/deutsche/easypopulate_4.php
+++ b/admin/includes/languages/deutsche/easypopulate_4.php
@@ -61,6 +61,19 @@ define('EASYPOPULATE_4_SPECIALS_DELETE', '<font color="fuchsia"><b>DELETED! - Mo
 define('EASYPOPULATE_4_SPECIALS_DELETE_FAIL', '<font color="darkviolet"><b>NOT FOUND! - Model:</b> %s - cannot delete special...</font><br />');
 define('EASYPOPULATE_4_SPECIALS_FOOTER', '</p>'); // close paragraph
 
+define('EP_DESC_PLURAL', 'Sie werden');
+define('EP_DESC_SING', 'Es wird');
+define('FEATURED_EP_DESC','Prefix: %1$s. %2$s durch die featured Filter ausgefuehrt werden.');
+define('PRICEQTY_EP_DESC','Prefix: %1$s. %2$s durch die Price Quantity Filter ausgefuehrt werden.');
+define('PRICEBREAKS_EP_DESC','Prefix: %1$s. %2$s durch die Price Breaks Filter ausgefuehrt werden.');
+define('CATEGORY_EP_DESC','Prefix: %1$s. %2$s durch die Category Filter ausgefuehrt werden.');
+define('CATEGORYMETA_EP_DESC','Prefix: %1$s. %2$s durch die Category Meta Filter ausgefuehrt werden.');
+define('ATTRIB_BASIC_EP','Prefix: %1$s. %2$s durch die Basic Attribute Filter ausgefuehrt werden.');
+define('ATTRIB_DETAILED_EP_DESC','Prefix: %1$s. %2$s durch die Detailed Attributes Filter ausgefuehrt werden.');
+define('SBA_DETAILED_EP_DESC','Prefix: %1$s. %2$s durch die Detailed Stock by Attributes Filter ausgefuehrt werden.');
+define('SBA_STOCK_EP_DESC','Prefix: %1$s. %2$s durch die Stock by Attributes Stock Modification Filter ausgefuehrt werden.');
+define('CATCHALL_EP_DESC', 'Alle anderen. %2$s durch die upload of a full data file Filter ausgefuehrt werden.');
+
 // error log defines - for ep_debug_log.txt
 define('EASYPOPULATE_4_ERRORLOG_SQL_ERROR', 'MySQL error %s: %s\nWhen executing:\n%sn');
 

--- a/admin/includes/languages/english/easypopulate_4.php
+++ b/admin/includes/languages/english/easypopulate_4.php
@@ -61,6 +61,19 @@ define('EASYPOPULATE_4_SPECIALS_DELETE', '<font color="fuchsia"><b>DELETED! - Mo
 define('EASYPOPULATE_4_SPECIALS_DELETE_FAIL', '<font color="darkviolet"><b>NOT FOUND! - Model:</b> %s - cannot delete special...</font><br />');
 define('EASYPOPULATE_4_SPECIALS_FOOTER', '</p>'); // close paragraph
 
+define('EP_DESC_PLURAL', 'They');
+define('EP_DESC_SING', 'It');
+define('FEATURED_EP_DESC','Prefix: %1$s. %2$s will be processed through the featured filters.');
+define('PRICEQTY_EP_DESC','Prefix: %1$s. %2$s will be processed through the Price Quantity filters.');
+define('PRICEBREAKS_EP_DESC','Prefix: %1$s. %2$s will be processed through the Price Breaks filters.');
+define('CATEGORY_EP_DESC','Prefix: %1$s. %2$s will be processed through the Category filters.');
+define('CATEGORYMETA_EP_DESC','Prefix: %1$s. %2$s will be processed through the Category Meta filters.');
+define('ATTRIB_BASIC_EP','Prefix: %1$s. %2$s will be processed through the Basic Attribute filters.');
+define('ATTRIB_DETAILED_EP_DESC','Prefix: %1$s. %2$s will be processed through the Detailed Attributes filters.');
+define('SBA_DETAILED_EP_DESC','Prefix: %1$s. %2$s will be processed through the Detailed Stock by Attributes filters.');
+define('SBA_STOCK_EP_DESC','Prefix: %1$s. %2$s will be processed through the Stock by Attributes Stock Modification filters.');
+define('CATCHALL_EP_DESC', 'This contains any other file. %2$s will be processed like the upload of a full data file.');
+
 // error log defines - for ep_debug_log.txt
 define('EASYPOPULATE_4_ERRORLOG_SQL_ERROR', 'MySQL error %s: %s\nWhen executing:\n%sn');
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -183,3 +183,8 @@
 					this program will not need to be updated merely to support a version check.
 					Incorporated admin logging of database inserts and updates similar (and beyond)
 					those contained in ZC 1.5.4.  Deletions were not incorporated.
+4.0.29   04-03-2015		Added support for products_map modification (Manufacturer's Advertised Price)
+					Added MSRP export to areas where previously begun but not fully incorporated.
+					Modified import of customid for SBA-detailed-attributes to treat as a string.
+					Began incorporating language overrides, specifically with German as the first alternate language.
+					Added support for the plugin dual pricing.

--- a/changelog.txt
+++ b/changelog.txt
@@ -188,3 +188,18 @@
 					Modified import of customid for SBA-detailed-attributes to treat as a string.
 					Began incorporating language overrides, specifically with German as the first alternate language.
 					Added support for the plugin dual pricing.
+4.0.30   06-27-2015		Added a new way of displaying files on the EP4 screen to show
+					more information such as the prefix to the file types that are
+					processed.  This is to reduce the questions related to not
+					reading the instructions and understanding that certain files
+					are processed only by their name prefix.  Everything else is 
+					processed as if it was a full update file.  Also addressed a
+					warning received in PHP 5.4+ related to testing a variable not
+					initialized.  Previously 'if (!$error)' was sufficient, which
+					it is if $error has been assigned; however, if not assigned,
+					this results in a warning message in the logs folder.  So,
+					instead to maintain consistent usage/functionality will check
+					if it is set and if it is set to verify that it is not an
+					error, and if it never was set then that would need to be 
+					known as well.  end result: if (!$error) { has been changed to
+					if ((isset($error) && !$error) || !isset($error)) {.


### PR DESCRIPTION
Added features, additional field recognized by certain software being installed, correction made for multi-language description import, addressed warning log file created for import when no errors generated on PHP 5.4+, began/continued German language incorporation to transition EP4 to a multi-lingual product as expected to submit as a ZC plugin, added a switchable option to the menu to clarify the operations expected when importing named files to align with the existing instruction but on a routine basis. Default operation if the menu is not updated/constant not assigned is to show all filetype groups and the file(s) in that group.  Second option available for only showing how the files present will be processed, and third option to display filenames as accustomed in the past.

Recommended upgrade, note configuration -> Easy Populate v4 settings; and then tools->Easy Populate v4, select uninstall in upper right hand corner.  Upload files, then select install at the top of the screen of tools->Easy Populate v4, restore settings in configuration window.